### PR TITLE
Add lib xcb to zeus.pro

### DIFF
--- a/zeal/zeal.pro
+++ b/zeal/zeal.pro
@@ -46,7 +46,7 @@ QMAKE_CXXFLAGS += -std=c++11
 win32:DEFINES += WIN32 QUAZIP_BUILD
 win32:LIBS += -lz
 
-unix:!macx: LIBS += -lxcb-keysyms
+unix:!macx: LIBS += -lxcb -lxcb-keysyms
 unix:!macx: SOURCES += xcb_keysym.cpp
 
 include (widgets/widgets.pri)


### PR DESCRIPTION
Without this lib I got error while building:

```
g++ -Wl,-O1 -Wl,-rpath-link,/usr/lib -o zeal main.o mainwindow.o zeallistmodel.o zealsearchmodel.o zealdocsetsregistry.o zealsearchresult.o zealnativeeventfilter.o lineedit.o zealsearchitemdelegate.o zealsearchitemstyle.o zealsettingsdialog.o xcb_keysym.o searchablewebview.o zealsearchedit.o razorshortcutbutton.o qioapi.o JlCompress.o quaadler32.o quacrc32.o quazip.o quazipfile.o quazipfileinfo.o quazipnewinfo.o unzip.o zip.o moc_mainwindow.o moc_zeallistmodel.o moc_zealsearchmodel.o moc_zealdocsetsregistry.o moc_zealnativeeventfilter.o moc_lineedit.o moc_zealsearchitemdelegate.o moc_zealsettingsdialog.o moc_searchablewebview.o moc_zealsearchedit.o moc_razorshortcutbutton.o moc_razorshortcutbutton_p.o moc_quazipfile.o   -lxcb-keysyms -lQt5WebKitWidgets -L/usr/lib -lX11 -lxslt -lz -lm -ludev -lgio-2.0 -lgstapp-0.10 -lgstinterfaces-0.10 -lgstpbutils-0.10 -pthread -lgstvideo-0.10 -lgstbase-0.10 -lgstreamer-0.10 -lgobject-2.0 -lgmodule-2.0 -lgthread-2.0 -lrt -lxml2 -lglib-2.0 -lsqlite3 -L/home/abuild/rpmbuild/BUILD/qtdeclarative-opensource-src-5.0.1/lib -L/home/abuild/rpmbuild/BUILD/qtwebkit-opensource-src-5.0.1/lib -lQt5Quick -lQt5OpenGL -lQt5PrintSupport -lQt5WebKit -lQt5Qml -lQt5Widgets -lQt5Xml -lQt5Sql -lQt5Network -lQt5Gui -lQt5Core -lGL -lpthread 
/usr/lib/gcc/i586-suse-linux/4.7/../../../../i586-suse-linux/bin/ld: zealnativeeventfilter.o: undefined reference to symbol 'xcb_allow_events'
/usr/lib/gcc/i586-suse-linux/4.7/../../../../i586-suse-linux/bin/ld: note: 'xcb_allow_events' is defined in DSO /usr/lib/libxcb.so.1 so try adding it to the linker command line
/usr/lib/libxcb.so.1: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
```
