### PR TITLE
Add ability to filter search by docstring

### DIFF
--- a/zeal/zeal.pro
+++ b/zeal/zeal.pro
@@ -24,7 +24,8 @@ SOURCES += main.cpp\
     zealsearchitemdelegate.cpp \
     zealsearchitemstyle.cpp \
     zealsettingsdialog.cpp \
-    zealnetworkaccessmanager.cpp
+    zealnetworkaccessmanager.cpp \
+    zealsearchquery.cpp
 
 HEADERS  += mainwindow.h \
     zeallistmodel.h \
@@ -37,7 +38,8 @@ HEADERS  += mainwindow.h \
     zealsearchitemstyle.h \
     zealsettingsdialog.h \
     xcb_keysym.h \
-    zealnetworkaccessmanager.h
+    zealnetworkaccessmanager.h \
+    zealsearchquery.h
 
 FORMS    += mainwindow.ui \
     zealsettingsdialog.ui

--- a/zeal/zealdocsetsregistry.h
+++ b/zeal/zealdocsetsregistry.h
@@ -14,6 +14,7 @@ class ZealDocsetsRegistry : public QObject
 {
     Q_OBJECT
 public:
+
     static ZealDocsetsRegistry* instance()
     {
         static QMutex mutex;
@@ -57,6 +58,7 @@ public:
         types.remove(name);
     }
 
+    QString prepareQuery(const QString& rawQuery);
     void runQuery(const QString& query);
     const QList<ZealSearchResult>& getQueryResults();
 

--- a/zeal/zealsearchitemdelegate.cpp
+++ b/zeal/zealsearchitemdelegate.cpp
@@ -5,6 +5,8 @@
 #include <QDebug>
 #include <QApplication>
 
+#include "zealsearchquery.h"
+
 ZealSearchItemDelegate::ZealSearchItemDelegate(QObject *parent, QLineEdit* lineEdit_, QWidget* view_) :
     QStyledItemDelegate(parent), lineEdit(lineEdit_), view(view_)
 {
@@ -46,7 +48,7 @@ void ZealSearchItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem
     auto elided = metrics.elidedText(index.data().toString(), option.textElideMode, rect.width());
     QString highlight;
     if(lineEdit) {
-        highlight = lineEdit->text();
+        highlight = ZealSearchQuery(lineEdit->text()).getCoreQuery();
     }
     int from = 0;
     while(from < elided.size()) {

--- a/zeal/zealsearchquery.cpp
+++ b/zeal/zealsearchquery.cpp
@@ -1,0 +1,53 @@
+#include <QString>
+#include <QStringList>
+
+#include "zealsearchquery.h"
+
+ZealSearchQuery::ZealSearchQuery()
+{
+    rawQuery = "";
+}
+
+ZealSearchQuery::ZealSearchQuery(const QString &rawQuery)
+{
+    this->rawQuery = rawQuery;
+}
+
+
+// Returns the docset filter for the given query.
+//
+// Examples:
+//   "android|setTypeFa" #=> "android"
+//   "noprefix"          #=> ""
+QString ZealSearchQuery::getDocsetFilter()
+{
+    if(rawQuery.indexOf(ZealSearchQuery::DOCSET_FILTER_SEPARATOR) >= 0) {
+        QString prefix = rawQuery.split(ZealSearchQuery::DOCSET_FILTER_SEPARATOR)[0];
+        return prefix.trimmed();
+    }
+
+    return "";
+}
+
+// Returns the core query, sanitized for use in SQL queries
+QString ZealSearchQuery::getSanitizedQuery()
+{
+    QString q = getCoreQuery();
+    q.replace("\\", "\\\\");
+    q.replace("_", "\\_");
+    q.replace("%", "\\%");
+    q.replace("'", "''");
+    return q;
+}
+
+// Returns the query with any docset prefixes removed.
+//
+// Examples:
+//   "android|setTypeFa" #=> "setTypeFa"
+//   "plain"             #=> "plain"
+QString ZealSearchQuery::getCoreQuery()
+{
+    QString docsetPrefix = getDocsetFilter();
+    int prefixLen = docsetPrefix.size() + 1; // Remove separator
+    return rawQuery.right(rawQuery.size() - prefixLen).trimmed();
+}

--- a/zeal/zealsearchquery.h
+++ b/zeal/zealsearchquery.h
@@ -1,0 +1,19 @@
+#ifndef ZEALSEARCHQUERY_H
+#define ZEALSEARCHQUERY_H
+
+class ZealSearchQuery
+{
+    QString rawQuery;
+
+public:
+    ZealSearchQuery();
+    ZealSearchQuery(const QString& rawQuery);
+
+    static const char DOCSET_FILTER_SEPARATOR = '|';
+
+    QString getDocsetFilter();
+    QString getSanitizedQuery();
+    QString getCoreQuery();
+};
+
+#endif // ZEALSEARCHQUERY_H


### PR DESCRIPTION
Adds a little syntax to allow filtering the search results to a specific (or a set of specific) docsets. This is a lightweight implementation of the similar feature in Dash.

The docset filter and the search query are delimited by a pipe character (`|`).

Examples:
- `ruby|set_x` will search all docsets containing `ruby` (e.g. `ironruby`, `ruby` and `ruby2`) for `set_x`
- `set_x` will search all docsets for `set_x`
- `||set_x` will search all docsets for `|set_x`.
