### PR TITLE
Focus first result

### DIFF
--- a/zeal/mainwindow.cpp
+++ b/zeal/mainwindow.cpp
@@ -391,6 +391,7 @@ MainWindow::MainWindow(QWidget *parent) :
         ui->treeView->reset();
         ui->treeView->setColumnHidden(1, true);
         ui->treeView->setCurrentIndex(zealSearch.index(0, 0, QModelIndex()));
+        ui->treeView->activated(ui->treeView->currentIndex());
     });
     connect(ui->lineEdit, &QLineEdit::textChanged, [&](const QString& text) {
         if(!text.isEmpty()) {


### PR DESCRIPTION
Shows the first result in the web view as soon as the query has completed.

This commit accidentally fell out from the previous plugin PR (it's essential since the search from command line doesn't work well otherwise).

Sorry about that.
