### PR TITLE
use the platform-specific proxy settings

### DIFF
--- a/zeal/mainwindow.cpp
+++ b/zeal/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include <QSettings>
 #include <QTimer>
 #include <QWebSettings>
+#include <QNetworkProxyFactory>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QAbstractNetworkCache>
@@ -50,6 +51,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow),
     settings("Zeal", "Zeal")
 {
+    // Use the platform-specific proxy settings
+    QNetworkProxyFactory::setUseSystemConfiguration(true);
+
     // server for detecting already running instances
     localServer = new QLocalServer(this);
     connect(localServer, &QLocalServer::newConnection, [&]() {


### PR DESCRIPTION
I enabled the use of the platform-specific proxy settings. I am now able to download and use docsets on my Windows box behind a firewall.
To test it, I had to download and install the Open-SSL libraries on my Windows machine. I don't know if that impacts the deployment process on your side.
