### PR TITLE
Maintain selection when changing tabs

### DIFF
--- a/zeal/zealsettingsdialog.cpp
+++ b/zeal/zealsettingsdialog.cpp
@@ -358,10 +358,15 @@ void ZealSettingsDialog::on_listView_clicked(const QModelIndex &index)
     ui->deleteButton->setEnabled(true);
 }
 
-void ZealSettingsDialog::on_tabWidget_currentChanged(int index)
+void ZealSettingsDialog::on_tabWidget_currentChanged()
 {
-    // This is needed so the docset list is up to date when the user views it
+    // Ensure the list is completely up to date
+    QModelIndex index = ui->listView->currentIndex();
     ui->listView->reset();
+
+    if (index.isValid()) {
+        ui->listView->setCurrentIndex(index);
+    }
 }
 
 void ZealSettingsDialog::on_buttonBox_accepted()

--- a/zeal/zealsettingsdialog.h
+++ b/zeal/zealsettingsdialog.h
@@ -41,7 +41,7 @@ private slots:
 
     void on_listView_clicked(const QModelIndex &index);
 
-    void on_tabWidget_currentChanged(int index);
+    void on_tabWidget_currentChanged();
 
     void on_buttonBox_accepted();
 


### PR DESCRIPTION
Fixes #44 by ensuring that we maintain the docset selection during tab changes.

---

Figured I'd try and help out with some of the "minor-bugs" for now. I'm not sold that this is the optimal solution, but it does prevent losing the selection without properly disabling the delete button for a docset.
