### PR TITLE
fix(#77): Make query parser more c++-friendly

### DIFF
--- a/zeal/zealsearchquery.cpp
+++ b/zeal/zealsearchquery.cpp
@@ -1,37 +1,26 @@
 #include <QString>
-#include <QStringList>
-
 #include "zealsearchquery.h"
 
-// Creates a search query from a string
-//
-// Examples:
-//   "android:setTypeFa" #=> docsetFilter = "android", coreQuery = "setTypeFa"
-//   "noprefix"          #=> docsetFilter = "", coreQuery = "noprefix"
-//   ":find"             #=> docsetFilter = "", coreQuery = ":find"
 ZealSearchQuery::ZealSearchQuery(const QString &rawQuery)
 {
-    this->coreQuery = rawQuery;
-    this->docsetFilter = "";
-
-    if(rawQuery.indexOf(ZealSearchQuery::DOCSET_FILTER_SEPARATOR) >= 1) {
-        QStringList partitioned = rawQuery.split(ZealSearchQuery::DOCSET_FILTER_SEPARATOR);
-        QString prefix = partitioned[0];
-        this->coreQuery = partitioned[1];
-        this->docsetFilter = prefix.trimmed();
+    const int sepAt = rawQuery.indexOf(DOCSET_FILTER_SEPARATOR);
+    const int next  = sepAt + 1;
+    if (sepAt >= 1
+        && (next >= rawQuery.size()
+            || rawQuery.at(next) != DOCSET_FILTER_SEPARATOR)) {
+        this->docsetFilter = rawQuery.leftRef(sepAt).toString().trimmed();
+        this->coreQuery = rawQuery.midRef(next).toString().trimmed();
+    } else {
+        this->docsetFilter = "";
+        this->coreQuery = rawQuery.trimmed();
     }
-
-    this->coreQuery = this->coreQuery.trimmed();
 }
 
-
-// Returns the docset filter for the given query.
 QString ZealSearchQuery::getDocsetFilter()
 {
     return this->docsetFilter;
 }
 
-// Returns the core query, sanitized for use in SQL queries
 QString ZealSearchQuery::getSanitizedQuery()
 {
     QString q = getCoreQuery();
@@ -42,7 +31,6 @@ QString ZealSearchQuery::getSanitizedQuery()
     return q;
 }
 
-// Returns the query with any docset prefixes removed.
 QString ZealSearchQuery::getCoreQuery()
 {
     return this->coreQuery;

--- a/zeal/zealsearchquery.h
+++ b/zeal/zealsearchquery.h
@@ -1,15 +1,37 @@
 #ifndef ZEALSEARCHQUERY_H
 #define ZEALSEARCHQUERY_H
 
+class QString;
+
+/**
+ * @short The search query model.
+ */
 class ZealSearchQuery
 {
 public:
-    ZealSearchQuery(const QString& coreQuery);
-
     static const char DOCSET_FILTER_SEPARATOR = ':';
 
+    /// Creates a search query from a string. Single separator will be
+    /// used to contstruct docset filter, but separator repeated twice
+    /// will be left inside coreQuery part since double semicolon is
+    /// used inside qualified symbol names in popular programming
+    /// languages (c++, ruby, perl, etc.).
+    ///
+    /// Examples:
+    ///   "android:setTypeFa" #=> docsetFilter = "android", coreQuery = "setTypeFa"
+    ///   "noprefix"          #=> docsetFilter = "", coreQuery = "noprefix"
+    ///   ":find"             #=> docsetFilter = "", coreQuery = ":find"
+    ///   "std::string"       #=> docsetFilter = "", coreQuery = "std::string"
+    ///   "c++:std::string"   #=> docsetFilter = "c++", coreQuery = "std::string"
+    ZealSearchQuery(const QString& coreQuery);
+
+    /// Returns the docset filter for the given query.
     QString getDocsetFilter();
+
+    /// Returns the core query, sanitized for use in SQL queries.
     QString getSanitizedQuery();
+
+    /// Returns the query with any docset prefixes removed.
     QString getCoreQuery();
 
 private:


### PR DESCRIPTION
Update ZealSearchQuery to process no semicolons but first
and to not consider several semicolons at the beginning
as docset filter separator.

Was:

```
c++:std::string => docset=c++ query=std
std::string     => docset=std query=
```

Now:

```
c++:std::string => docset=c++ query=std::string
std::string     => docset=    query=std::string
```

See https://github.com/jkozera/zeal/issues/77
