### PR TITLE
Wait for docset unpacking in DownloadCompleteCb

### DIFF
--- a/zeal/zealsettingsdialog.cpp
+++ b/zeal/zealsettingsdialog.cpp
@@ -294,6 +294,7 @@ void ZealSettingsDialog::DownloadCompleteCb(QNetworkReply *reply){
                         listItem->setData(ProgressItemDelegate::ProgressMaxRole, 0);
                     }
                     tar->start(program, args);
+                    tar->waitForFinished();
                 }
             } else {
                 QTemporaryFile *tmp = new QTemporaryFile;


### PR DESCRIPTION
Branch at DownloadCompleteCb now waits for docset unpacking and only
after sends completion signal to docset progress bar and total progress
bar.

This fix will probably close #50.
Docset progress bar now waits for docset unpacking and only after shows
