### PR TITLE
Fix the tray icon problem in Unity

### DIFF
--- a/zeal/mainwindow.h
+++ b/zeal/mainwindow.h
@@ -12,6 +12,13 @@
 #include "zealnativeeventfilter.h"
 #include "zealsettingsdialog.h"
 
+#ifdef LINUX
+#undef signals
+#include <libappindicator/app-indicator.h>
+#define signals public
+#endif
+
+
 namespace Ui {
 class MainWindow;
 }
@@ -45,6 +52,7 @@ private:
     ZealNativeEventFilter nativeFilter;
     ZealSettingsDialog settingsDialog;
     QSystemTrayIcon *trayIcon;
+    AppIndicator *indicator;  //for Unity
     QMenu *trayIconMenu;
     QMap<QString, QString> urls;
     QString getDocsetName(QString urlPath);

--- a/zeal/zeal.pro
+++ b/zeal/zeal.pro
@@ -43,6 +43,10 @@ HEADERS  += mainwindow.h \
     zealsearchquery.h \
     progressitemdelegate.h
 
+INCLUDEPATH += /usr/include/libappindicator-0.1 \
+        /usr/include/gtk-2.0 \
+        /usr/lib/gtk-2.0/include \
+
 FORMS    += mainwindow.ui \
     zealsettingsdialog.ui
 
@@ -55,7 +59,11 @@ macx:CONFIG += c++11
 
 win32:DEFINES += WIN32 QUAZIP_BUILD
 DEFINES += ZEAL_VERSION=\\\"20140215\\\"
-LIBS += -lz
+LIBS += -lz -L/usr/lib -lappindicator
+
+CONFIG += link_pkgconfig
+
+PKGCONFIG = gtk+-2.0
 
 unix:!macx: LIBS += -lxcb -lxcb-keysyms
 unix:!macx: SOURCES += xcb_keysym.cpp


### PR DESCRIPTION
Tray icon is displayed wrong in Ubuntu 14.04, as shown in [issue 148](https://github.com/jkozera/zeal/issues/148). Then, I use application indicator instead of tray icon in Ubuntu 14.04 following the instructions. 

Note: left-click on application indicator won't show the application. This is the feature of application indicator. We can use hotkey to show the application. 

New requirements: libgtk2.0-dev libappindicator-dev
