### PR TITLE
Make libappindicator dependency optional

### DIFF
--- a/zeal/mainwindow.cpp
+++ b/zeal/mainwindow.cpp
@@ -26,13 +26,16 @@
 #include <windows.h>
 #endif
 
+#ifdef USE_LIBAPPINDICATOR
+#include <gtk/gtk.h>
+#endif
+
 #ifdef LINUX
 #include <qpa/qplatformnativeinterface.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_keysyms.h>
 #include <X11/keysym.h>
 #include "xcb_keysym.h"
-#include <gtk/gtk.h>
 #endif
 
 const QString serverName = "zeal_process_running";
@@ -44,7 +47,7 @@ MainWindow::MainWindow(QWidget *parent) :
     settingsDialog(zealList)
 {
     trayIcon = nullptr;
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
     indicator = nullptr;
 #endif
     trayIconMenu = nullptr;
@@ -93,7 +96,7 @@ MainWindow::MainWindow(QWidget *parent) :
         if(!isVisible() || !isActiveWindow()) {
             bringToFront(true);
         } else {
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
             if(trayIcon || indicator) {
 #else
             if(trayIcon) {
@@ -267,7 +270,7 @@ void MainWindow::forward() {
     displayViewActions();
 }
 
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
 void onQuit(GtkMenu *menu, gpointer data)
 {
     Q_UNUSED(menu);
@@ -278,7 +281,7 @@ void onQuit(GtkMenu *menu, gpointer data)
 
 void MainWindow::createTrayIcon()
 {
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
     if(trayIcon || indicator) return;
 #else
     if(trayIcon) return;
@@ -290,7 +293,7 @@ void MainWindow::createTrayIcon()
     desktop = getenv("XDG_CURRENT_DESKTOP");
     isUnity = (desktop.toLower() == "unity");
 
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
     if(isUnity) //Application Indicators for Unity
     {
         GtkWidget *menu;
@@ -323,7 +326,7 @@ void MainWindow::createTrayIcon()
             }
         });
         trayIcon->show();
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
     }
 #endif
 }

--- a/zeal/mainwindow.h
+++ b/zeal/mainwindow.h
@@ -12,7 +12,7 @@
 #include "zealnativeeventfilter.h"
 #include "zealsettingsdialog.h"
 
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
 #undef signals
 #include <libappindicator/app-indicator.h>
 #define signals public
@@ -52,7 +52,7 @@ private:
     ZealNativeEventFilter nativeFilter;
     ZealSettingsDialog settingsDialog;
     QSystemTrayIcon *trayIcon;
-#ifdef LINUX
+#ifdef USE_LIBAPPINDICATOR
     AppIndicator *indicator;  //for Unity
 #endif
     QMenu *trayIconMenu;

--- a/zeal/zeal.pro
+++ b/zeal/zeal.pro
@@ -45,10 +45,6 @@ HEADERS  += mainwindow.h \
     progressitemdelegate.h \
     zealdocsetmetadata.h
 
-unix:!macx: INCLUDEPATH += /usr/include/libappindicator-0.1 \
-        /usr/include/gtk-2.0 \
-        /usr/lib/gtk-2.0/include \
-
 FORMS    += mainwindow.ui \
     zealsettingsdialog.ui
 
@@ -66,11 +62,19 @@ LIBS += -lz -L/usr/lib
 
 CONFIG += link_pkgconfig
 
-unix:!macx: PKGCONFIG = gtk+-2.0
-
-unix:!macx: LIBS += -lxcb -lxcb-keysyms -lappindicator
+unix:!macx: LIBS += -lxcb -lxcb-keysyms
 unix:!macx: SOURCES += xcb_keysym.cpp
 unix:!macx: DEFINES += LINUX
+
+unix:!macx:!no_libappindicator {
+    INCLUDEPATH += /usr/include/libappindicator-0.1 \
+        /usr/include/gtk-2.0 \
+        /usr/lib/gtk-2.0/include
+    PKGCONFIG = gtk+-2.0
+    LIBS += -lappindicator
+
+    DEFINES += USE_LIBAPPINDICATOR
+}
 
 appicons16.path=/usr/share/icons/hicolor/16x16/apps
 appicons24.path=/usr/share/icons/hicolor/24x24/apps


### PR DESCRIPTION
So `qmake "CONFIG+=no_libappindicator" && make` will build the app without libappindicator and gtk dependencies.
