### PR TITLE
Fix bugs in settings dialog

### DIFF
--- a/zeal/zealsettingsdialog.cpp
+++ b/zeal/zealsettingsdialog.cpp
@@ -775,8 +775,7 @@ void ZealSettingsDialog::saveSettings(){
     settings.setValue("httpProxy", ui->m_httpProxy->text());
     settings.setValue("httpProxyPort", ui->m_httpProxyPort->value());
     settings.setValue("httpProxyUser", ui->m_httpProxyUser->text());
-    settings.setValue("httpProxy", ui->m_httpProxyPass->text());
-
+    settings.setValue("httpProxyPass", ui->m_httpProxyPass->text());
     settings.setValue("prefixes", prefixes);
 }
 


### PR DESCRIPTION
This fixes:
- #191 httpProxyPass overwrote httpProxy, so it appeared as if it wasn't saved
- #193, and what system proxy actually means is [platform-dependent](http://qt-project.org/doc/qt-5/qnetworkproxyfactory.html#systemProxyForQuery).
