### PR TITLE
Implement createWindow()

### DIFF
--- a/zeal/mainwindow.h
+++ b/zeal/mainwindow.h
@@ -59,13 +59,13 @@ public:
     ~MainWindow();
     void bringToFrontAndSearch(const QString);
     bool startHidden();
+    void createTab();
 
 private:
     void bringToFront(bool withHack);
     void displayViewActions();
     void loadSections(const QString docsetName, const QUrl &url);
     void setupSearchBoxCompletions();
-    void createTab();
     void reloadTabState();
     void displayTabs();
     void updateTreeView(QString text);

--- a/zeal/widgets/searchablewebview.h
+++ b/zeal/widgets/searchablewebview.h
@@ -3,6 +3,7 @@
 
 #include <QWebView>
 #include <QWebSettings>
+#include "zealwebview.h"
 #include "../lineedit.h"
 
 class SearchableWebView : public QWidget
@@ -34,7 +35,7 @@ public slots:
     
 private:
     LineEdit lineEdit;
-    QWebView webView;
+    ZealWebView webView;
     QString searchText;
     void moveLineEdit();
 };

--- a/zeal/widgets/widgets.pri
+++ b/zeal/widgets/widgets.pri
@@ -1,8 +1,10 @@
 HEADERS += widgets/searchablewebview.h \
     widgets/zealsearchedit.h \
     widgets/razorshortcutbutton.h \
-    widgets/razorshortcutbutton_p.h
+    widgets/razorshortcutbutton_p.h \
+    widgets/zealwebview.h
 
 SOURCES += widgets/searchablewebview.cpp \
     widgets/zealsearchedit.cpp \
-    widgets/razorshortcutbutton.cpp
+    widgets/razorshortcutbutton.cpp \
+    widgets/zealwebview.cpp

--- a/zeal/widgets/zealwebview.cpp
+++ b/zeal/widgets/zealwebview.cpp
@@ -1,0 +1,12 @@
+#include "zealwebview.h"
+#include "../mainwindow.h"
+
+ZealWebView::ZealWebView(QWidget *parent) : QWebView(parent) {};
+
+QWebView *ZealWebView::createWindow(QWebPage::WebWindowType type) {
+    Q_UNUSED(type)
+
+    MainWindow *mw = qobject_cast<MainWindow *>(qApp->activeWindow());
+    mw->createTab();
+    return this;
+}

--- a/zeal/widgets/zealwebview.h
+++ b/zeal/widgets/zealwebview.h
@@ -1,0 +1,22 @@
+#ifndef ZEALWEBVIEW_H
+#define ZEALWEBVIEW_H
+
+#include <QWebView>
+
+// Subclass QWebView so we can override createWindow
+class ZealWebView : public QWebView
+{
+    Q_OBJECT
+public:
+    explicit ZealWebView(QWidget *parent = 0);
+
+protected:
+    virtual QWebView *createWindow(QWebPage::WebWindowType type);
+
+signals:
+
+public slots:
+
+};
+
+#endif // ZEALWEBVIEW_H


### PR DESCRIPTION
Fixes #141. Replace plain `QWebView` with a tiny subclass that implements `createWindow()` by calling `createTab()` from `MainWindow` and returning self. 

It's a bit surprising it took so little work. This is probably because `createWindow` is called before `urlChanged` fires, and at that moment `searchState` is already set to the new tab.
