### PR TITLE
MSVC Fixes

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -94,7 +94,7 @@ void Application::extract(const QString &filePath, const QString &destination)
 QNetworkReply *Application::download(const QUrl &url)
 {
     QNetworkRequest request(url);
-    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("Zeal/" ZEAL_VERSION));
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("Zeal/") + QStringLiteral(ZEAL_VERSION));
     return m_networkManager->get(request);
 }
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -146,10 +146,10 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
 
     connect(ui->action_About, &QAction::triggered, [this]() {
         QMessageBox::about(this, QStringLiteral("About Zeal"),
-                           QStringLiteral("This is Zeal "
-                                          ZEAL_VERSION
-                                          " - a documentation browser.\n\n"
-                                          "For details see http://zealdocs.org/"));
+                           QStringLiteral("This is Zeal ") +
+                           QStringLiteral(ZEAL_VERSION) +
+                           QStringLiteral(" - a documentation browser.\n\n") +
+                           QStringLiteral("For details see http://zealdocs.org/"));
     });
     connect(ui->action_About_QT, &QAction::triggered, [this]() {
         QMessageBox::aboutQt(this);

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -396,7 +396,8 @@ void SettingsDialog::processDocsetList(const QJsonArray &list)
 {
     for (const QJsonValue &v : list) {
         QJsonObject docsetJson = v.toObject();
-        docsetJson[QStringLiteral("source")] = QStringLiteral("kapeli");
+        QString source = QStringLiteral("source");
+        docsetJson[source] = QStringLiteral("kapeli");
 
         DocsetMetadata metadata(docsetJson);
         m_availableDocsets.insert(metadata.name(), metadata);


### PR DESCRIPTION
Because on MSVC Qt uses wchar_t, QStringLiteral can only be applied on one constant string at a time.