### PR TITLE
Skip prettyProductName and currentCpuArchitecture if not on QT5.4+

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -118,8 +118,13 @@ QNetworkReply *Application::download(const QUrl &url)
 {
     const static QString userAgent = QString("Zeal/%1 (%2 %3; Qt/%4)")
             .arg(QCoreApplication::applicationVersion())
+#if QT_VERSION >= 0x050400
             .arg(QSysInfo::prettyProductName())
             .arg(QSysInfo::currentCpuArchitecture())
+#else
+            .arg("uknown-product")
+            .arg("unknown-arch")
+#endif
             .arg(qVersion());
 
     QNetworkRequest request(url);


### PR DESCRIPTION
This makes Zeal compile with no errors on QT 5.3.2, as shipped with Debian Jessie.