### PR TITLE
Fixed unwanted reset of overall progress bar and download button text wh...

### DIFF
--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -358,15 +358,18 @@ void SettingsDialog::displayProgress()
 
 void SettingsDialog::resetProgress()
 {
-    m_combinedReceived = 0;
-    m_combinedTotal = 0;
-    displayProgress();
+    if(replies.isEmpty())
+    {
+        m_combinedReceived = 0;
+        m_combinedTotal = 0;
+        displayProgress();
 
-    ui->downloadDocsetButton->setText(tr("Download"));
-    ui->refreshButton->setEnabled(true);
-    ui->updateButton->setEnabled(true);
-    ui->addFeedButton->setEnabled(true);
-    ui->availableDocsetList->setEnabled(true);
+        ui->downloadDocsetButton->setText(tr("Download"));
+        ui->refreshButton->setEnabled(true);
+        ui->updateButton->setEnabled(true);
+        ui->addFeedButton->setEnabled(true);
+        ui->availableDocsetList->setEnabled(true);
+    }
 }
 
 void SettingsDialog::updateDocsets()
@@ -480,9 +483,6 @@ void SettingsDialog::on_downloadDocsetButton_clicked()
 
         downloadDashDocset(item->data(ListModel::DocsetNameRole).toString());
     }
-
-    if (replies.count() > 0)
-        ui->downloadDocsetButton->setText(tr("Stop downloads"));
 }
 
 void SettingsDialog::on_storageButton_clicked()


### PR DESCRIPTION
...en downloading multiple docsets.

* Added a simple if(replies.isEmpty()) to prevent progress bar and button text reset when downloads are pending.
* Removed a redundant setText() from download button slot. (Already called via: on_downloadDocsetButton_clicked()->downloadDashDocset()->startDownload())