### PR TITLE
bigger settings dialog

### DIFF
--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -95,6 +95,7 @@ SettingsDialog::SettingsDialog(Core::Application *app, ListModel *listModel, QWi
             this, &SettingsDialog::extractionProgress);
 
     loadSettings();
+    ui->tabWidget->setCurrentIndex(0);
 }
 
 SettingsDialog::~SettingsDialog()

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -53,6 +53,9 @@ SettingsDialog::SettingsDialog(Core::Application *app, ListModel *listModel, QWi
     m_docsetRegistry(app->docsetRegistry())
 {
     ui->setupUi(this);
+    Qt::WindowFlags flags = windowFlags();
+    flags |= Qt::WindowMaximizeButtonHint;
+    setWindowFlags( flags );
 
 #ifdef Q_OS_OSX
     ui->availableDocsetList->setAttribute(Qt::WA_MacShowFocusRect, false);


### PR DESCRIPTION
Hello,

thank you for making this app. one thing I don't like when using Windows, is that all settings dialog are always too small. especially unresizable list views.

thanks to you, you've written this app in Qt ! Hurray

so here, i am doing 3 things.

* adding maximize button on settings dialog
* set first tab automatically on settingsdialog controller. otherwise, that last tab remains select even after app restart and the downloadable docsets list isn't loaded properly.
* I am adding a QGroupBox around the top part for installed docsets.

I tried to make the two groupbox into a vertical layout that includes a splitter, but I could not get QtCreator to do that for me.

let me know if you are interesting merging, I will solve conflit.
I hope it's not in the XML, but I have strong feeling it must be, isn't it ?


