### PR TITLE
core: link with libarchive on MacOS platform

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -8,3 +8,8 @@ unix:!macx {
 win32: {
     LIBS += -larchive_static -lz
 }
+
+macx: {
+    INCLUDEPATH += /usr/local/include
+    LIBS += -L/usr/local/lib -larchive
+}


### PR DESCRIPTION
This change allow to link libarchive on mac platform with a default libarchive installation.