### PR TITLE
support delay query after typing

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -41,6 +41,7 @@ namespace {
 const char GroupBrowser[] = "browser";
 const char GroupDocsets[] = "docsets";
 const char GroupGlobalShortcuts[] = "global_shortcuts";
+const char GroupQueryBehavior[] = "query_behavior";
 const char GroupInternal[] = "internal";
 const char GroupState[] = "state";
 const char GroupProxy[] = "proxy";
@@ -86,6 +87,10 @@ void Settings::load()
 #else
     showShortcut = m_settings->value(QStringLiteral("show"), QStringLiteral("Alt+Space")).value<QKeySequence>();
 #endif
+    m_settings->endGroup();
+
+    m_settings->beginGroup(GroupQueryBehavior);
+    delayQueryMs = m_settings->value(QStringLiteral("delay_query_ms"),0).toUInt();
     m_settings->endGroup();
 
     m_settings->beginGroup(GroupBrowser);
@@ -162,6 +167,10 @@ void Settings::save()
     m_settings->setValue(QStringLiteral("path"), docsetPath);
     m_settings->endGroup();
 #endif
+
+    m_settings->beginGroup(GroupQueryBehavior);
+    m_settings->setValue(QStringLiteral("delay_query_ms"),delayQueryMs);
+    m_settings->endGroup();
 
     m_settings->beginGroup(GroupState);
     m_settings->setValue(QStringLiteral("window_geometry"), windowGeometry);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -83,6 +83,9 @@ public:
     // Other
     QString docsetPath;
 
+    // Query Behavior
+    int delayQueryMs;
+
     // State
     QByteArray windowGeometry;
     QByteArray splitterGeometry;

--- a/src/ui/forms/settingsdialog.ui
+++ b/src/ui/forms/settingsdialog.ui
@@ -142,6 +142,42 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="queryGroupBox">
+         <property name="title">
+          <string>Query behavior</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;after typing query ,delay small amount of time before query (completion will also be delayed, press Enter query immediately). provide better performance when you have lots of docset or typing very long query. 0 value disable this feature completely.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Delay to begin query</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="delayQueryMsSpinBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;delay time in milliseconds ,300 ms is good for most people. you can try smaller value if you want result show faster and typing fast enough .up to 5000 (5s)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="maximum">
+             <number>5000</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>(ms)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -48,6 +48,7 @@ class QTabBar;
 class QWebHistory;
 class QWebHistoryItem;
 class QWebPage;
+class QTimer;
 
 namespace Ui {
 class MainWindow;
@@ -153,6 +154,7 @@ private:
 
     QSystemTrayIcon *m_trayIcon = nullptr;
 
+    QTimer *m_delayQueryTimer = nullptr;
 #ifdef USE_APPINDICATOR
     _AppIndicator *m_appIndicator = nullptr;
     _GtkWidget *m_appIndicatorMenu = nullptr;

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -752,6 +752,7 @@ void SettingsDialog::loadSettings()
     ui->minFontSize->setValue(settings->minimumFontSize);
     ui->storageEdit->setText(QDir::toNativeSeparators(settings->docsetPath));
 
+    ui->delayQueryMsSpinBox->setValue(settings->delayQueryMs);
     // Network Tab
     switch (settings->proxyType) {
     case Core::Settings::ProxyType::None:
@@ -792,6 +793,7 @@ void SettingsDialog::saveSettings()
         m_docsetRegistry->init(settings->docsetPath);
     }
 
+    settings->delayQueryMs = ui->delayQueryMsSpinBox->value();
     // Network Tab
     // Proxy settings
     if (ui->noProxySettings->isChecked())

--- a/src/ui/widgets/searchedit.cpp
+++ b/src/ui/widgets/searchedit.cpp
@@ -106,6 +106,8 @@ void SearchEdit::keyPressEvent(QKeyEvent *event)
         event->accept();
         break;
     case Qt::Key_Return:
+        //makes behavior likes LineEdit
+        emit returnPressed();
         emit m_treeView->activated(m_treeView->selectionModel()->currentIndex());
         event->accept();
         break;


### PR DESCRIPTION
zeal makes query everytime a char typed, this makes lots query before complete word
typed. this model not work very well with lots docset  . this commit introduce a delay time
which user can adjust after char typing ,so most unexpected query filtered out. user can
still press return to query immediately. to keep zeal default behavior as previously, this
setting default set to zero (disabled)