### PR TITLE
Improve search performance (caching, cancellation, parallel search)

### DIFF
--- a/src/registry/cachingsearchstrategy.cpp
+++ b/src/registry/cachingsearchstrategy.cpp
@@ -1,0 +1,98 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Oleg Shparber
+** Copyright (C) 2013-2014 Jerzy Kozera
+** Contact: http://zealdocs.org/contact.html
+**
+** This file is part of Zeal.
+**
+** Zeal is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** Zeal is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Zeal. If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "cachingsearchstrategy.h"
+
+#include "docset.h"
+#include "searchquery.h"
+#include "searchresult.h"
+
+using namespace Zeal;
+
+const int CacheSize = 10;
+
+CachingSearchStrategy::CachingSearchStrategy(std::unique_ptr<DocsetSearchStrategy> strategy)
+    : m_search(std::move(strategy))
+    , m_cache(CacheSize)
+{
+}
+
+QList<SearchResult> CachingSearchStrategy::search(const QString &query, const CancellationToken &token)
+{
+    QString candidate = getCacheEntry(query);
+    if (!candidate.isEmpty()) {
+        return searchWithCache(query, candidate);
+    } else {
+        return searchWithoutCache(query, token);
+    }
+}
+
+bool CachingSearchStrategy::validResult(
+        const QString &query, const SearchResult &previousResult,
+        SearchResult &result) const
+{
+    return m_search->validResult(query, previousResult, result);
+}
+
+QString CachingSearchStrategy::getCacheEntry(const QString &query) const
+{
+    const SearchQuery searchQuery = SearchQuery::fromString(query);
+
+    for (int i = searchQuery.query().size(); i > 0; i--) {
+        QString candidate = searchQuery.query().mid(0, i);
+
+        /// Use the cache only if the cache entry contains all results.
+        /// Also handle cases where prefix is a docset query `std:`.
+        if (m_cache.contains(candidate)
+                && m_cache[candidate]->size() < Docset::MaxDocsetResultsCount
+                && SearchQuery::fromString(candidate).query().size() == i)
+            return candidate;
+    }
+    return QString();
+}
+
+QList<SearchResult> CachingSearchStrategy::searchWithCache(const QString &query, const QString &prefix)
+{
+    QList<SearchResult> *prefixResults = m_cache[prefix];
+    QList<SearchResult> results;
+    QListIterator<SearchResult> prefixResultsIterator(*prefixResults);
+    while (prefixResultsIterator.hasNext()) {
+        SearchResult previousResult = prefixResultsIterator.next();
+        SearchResult result;
+        if (validResult(query, previousResult, result))
+            results.append(result);
+    }
+
+    m_cache.insert(query, new QList<SearchResult>(results));
+    return results;
+}
+
+QList<SearchResult> CachingSearchStrategy::searchWithoutCache(const QString &query, CancellationToken token)
+{
+    QList<SearchResult> results = m_search->search(query, token);
+
+    /// Only cache the results if they are not partial.
+    if (!token.isCanceled())
+        m_cache.insert(query, new QList<SearchResult>(results));
+    return results;
+}

--- a/src/registry/cachingsearchstrategy.h
+++ b/src/registry/cachingsearchstrategy.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Oleg Shparber
+** Copyright (C) 2013-2014 Jerzy Kozera
+** Contact: http://zealdocs.org/contact.html
+**
+** This file is part of Zeal.
+**
+** Zeal is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** Zeal is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Zeal. If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#ifndef CACHINGSEARCHSTRATEGY_H
+#define CACHINGSEARCHSTRATEGY_H
+
+#include "cancellationtoken.h"
+#include "docsetsearchstrategy.h"
+
+#include <QCache>
+#include <QList>
+#include <QString>
+
+#include <memory>
+
+namespace Zeal {
+
+struct SearchResult;
+
+/// A search strategy that uses a cache of previous searches.
+/// If a search was made for a prefix then then all results
+/// must appear in the cache. In this case instead of searching
+/// entire docset only cache is searched.
+class CachingSearchStrategy : public DocsetSearchStrategy
+{
+public:
+    CachingSearchStrategy(std::unique_ptr<DocsetSearchStrategy> strategy);
+    QList<SearchResult> search(const QString &query, const CancellationToken &token) override;
+    bool validResult(const QString &query, const SearchResult &previousResult,
+                     SearchResult &result) const override;
+
+private:
+    QString getCacheEntry(const QString &query) const;
+    QList<SearchResult> searchWithCache(const QString &query, const QString &prefix);
+    QList<SearchResult> searchWithoutCache(const QString &query, CancellationToken token);
+
+    std::unique_ptr<DocsetSearchStrategy> m_search;
+    QCache<QString, QList<SearchResult> > m_cache;
+};
+
+}
+
+#endif // CACHINGSEARCHSTRATEGY_H

--- a/src/registry/docset.cpp
+++ b/src/registry/docset.cpp
@@ -22,16 +22,20 @@
 ****************************************************************************/
 
 #include "docset.h"
+#include "docsetsearchstrategy.h"
+#include "searchresult.h"
 
 #include "cancellationtoken.h"
 #include "searchquery.h"
 #include "searchresult.h"
 #include "util/plist.h"
 
+#include <algorithm>
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QRegularExpression>
 #include <QSqlError>
 #include <QSqlQuery>
 #include <QUrl>
@@ -56,8 +60,87 @@ const char IsJavaScriptEnabled[] = "isJavaScriptEnabled";
 }
 }
 
+namespace Zeal {
+
+class DashSearchStrategy : public DocsetSearchStrategy
+{
+public:
+    explicit DashSearchStrategy(Docset *docset);
+    QList<SearchResult> search(const QString &query, const CancellationToken &token) const;
+
+private:
+    Docset *m_docset;
+};
+
+}
+
+DashSearchStrategy::DashSearchStrategy(Docset *docset)
+    : m_docset(docset)
+{
+}
+
+QList<SearchResult> DashSearchStrategy::search(const QString &rawQuery, const CancellationToken &token) const
+{
+    QList<SearchResult> results;
+    int resultCount = 0;
+
+    const SearchQuery searchQuery = SearchQuery::fromString(rawQuery);
+    const QString sanitizedQuery = searchQuery.sanitizedQuery();
+
+    if (searchQuery.hasKeywords() && !searchQuery.hasKeywords(m_docset->keywords()))
+        return QList<SearchResult>();
+
+    QString queryStr;
+
+    // Search all substrings
+    QString curQuery = QLatin1Char('%') + sanitizedQuery;
+    if (m_docset->type() == Docset::Type::Dash) {
+        queryStr = QString("SELECT name, type, path "
+                           "    FROM searchIndex "
+                           "WHERE (name LIKE :query ESCAPE '\\') ");
+    } else {
+        queryStr = QString("SELECT ztokenname, ztypename, zpath, zanchor "
+                           "    FROM ztoken "
+                           "JOIN ztokenmetainformation "
+                           "    ON ztoken.zmetainformation = ztokenmetainformation.z_pk "
+                           "JOIN zfilepath "
+                           "    ON ztokenmetainformation.zfile = zfilepath.z_pk "
+                           "JOIN ztokentype "
+                           "    ON ztoken.ztokentype = ztokentype.z_pk "
+                           "WHERE (ztokenname LIKE :query ESCAPE '\\') ");
+    }
+
+    QSqlQuery query(m_docset->database());
+    query.prepare(queryStr);
+    query.bindValue(":query", QString("%1%").arg(curQuery));
+    query.exec();
+
+    while (query.next() && resultCount < Docset::MaxDocsetResultsCount) {
+        const QString itemName = query.value(0).toString();
+        QString path = query.value(2).toString();
+        if (m_docset->type() == Docset::Type::ZDash) {
+            const QString anchor = query.value(3).toString();
+            if (!anchor.isEmpty())
+                path += QLatin1Char('#') + anchor;
+        }
+
+        int score = Docset::scoreSubstringResult(searchQuery, itemName);
+        // TODO: Third should be type
+        SearchResult newResult(SearchResult{itemName, QString(),
+                               m_docset->parseSymbolType(query.value(1).toString()),
+                               const_cast<Docset *>(m_docset),
+                               path, sanitizedQuery, score});
+
+        results << newResult;
+        resultCount++;
+    }
+
+    return results;
+}
+
 Docset::Docset(const QString &path) :
-    m_path(path)
+    m_path(path),
+    m_searchStrategy(new DashSearchStrategy(this))
 {
     QDir dir(m_path);
     if (!dir.exists())
@@ -199,11 +282,6 @@ QString Docset::revision() const
     return m_revision;
 }
 
-QString Docset::path() const
-{
-    return m_path;
-}
-
 QString Docset::documentPath() const
 {
     return QDir(m_path).absoluteFilePath(QStringLiteral("Contents/Resources/Documents"));
@@ -227,6 +305,11 @@ QString Docset::indexFilePath() const
     return QDir(documentPath()).absoluteFilePath(m_indexFilePath);
 }
 
+Docset::Type Docset::type() const
+{
+    return m_type;
+}
+
 QMap<QString, int> Docset::symbolCounts() const
 {
     return m_symbolCounts;
@@ -244,79 +327,35 @@ const QMap<QString, QString> &Docset::symbols(const QString &symbolType) const
     return m_symbols[symbolType];
 }
 
-QList<SearchResult> Docset::search(const QString &query, const CancellationToken &token) const
+bool Docset::endsWithSeparator(QString result, int pos)
 {
-    QList<SearchResult> results;
+    QString beforeMatch = result.mid(0, pos);
+    return beforeMatch.endsWith(".") || beforeMatch.endsWith("::") || beforeMatch.endsWith("/");
+}
 
-    const SearchQuery searchQuery = SearchQuery::fromString(query);
-    const QString sanitizedQuery = searchQuery.sanitizedQuery();
+int Docset::separators(QString result, int pos)
+{
+    QRegularExpression separator("\\.|::|/");
+    return result.mid(0, pos).count(separator);
+}
 
-    if (searchQuery.hasKeywords() && !searchQuery.hasKeywords(m_keywords))
-        return results;
+int Docset::scoreSubstringResult(const SearchQuery &query, const QString result)
+{
+    int score = TotalBuckets - 1;
 
-    QString queryStr;
-
-    bool withSubStrings = false;
-    // %.%1% for long Django docset values like django.utils.http
-    // %::%1% for long C++ docset values like std::set
-    // %/%1% for long Go docset values like archive/tar
-    QString subNames = QStringLiteral(" OR %1 LIKE '%.%2%' ESCAPE '\\'");
-    subNames += QLatin1String(" OR %1 LIKE '%::%2%' ESCAPE '\\'");
-    subNames += QLatin1String(" OR %1 LIKE '%/%2%' ESCAPE '\\'");
-    while (!token.isCanceled() && results.size() < 100) {
-        QString curQuery = sanitizedQuery;
-        QString notQuery; // don't return the same result twice
-        if (withSubStrings) {
-            // if less than 100 found starting with query, search all substrings
-            curQuery = QLatin1Char('%') + sanitizedQuery;
-            // don't return 'starting with' results twice
-            if (m_type == Docset::Type::Dash)
-                notQuery = QString(" AND NOT (name LIKE '%1%' ESCAPE '\\' %2) ").arg(sanitizedQuery, subNames.arg("name", sanitizedQuery));
-            else
-                notQuery = QString(" AND NOT (ztokenname LIKE '%1%' ESCAPE '\\' %2) ").arg(sanitizedQuery, subNames.arg("ztokenname", sanitizedQuery));
-        }
-        if (m_type == Docset::Type::Dash) {
-            queryStr = QString("SELECT name, type, path "
-                               "    FROM searchIndex "
-                               "WHERE (name LIKE '%1%' ESCAPE '\\' %3) %2 "
-                               "ORDER BY name COLLATE NOCASE LIMIT 100")
-                    .arg(curQuery, notQuery, subNames.arg("name", curQuery));
-        } else {
-            queryStr = QString("SELECT ztokenname, ztypename, zpath, zanchor "
-                               "    FROM ztoken "
-                               "JOIN ztokenmetainformation "
-                               "    ON ztoken.zmetainformation = ztokenmetainformation.z_pk "
-                               "JOIN zfilepath "
-                               "    ON ztokenmetainformation.zfile = zfilepath.z_pk "
-                               "JOIN ztokentype "
-                               "    ON ztoken.ztokentype = ztokentype.z_pk "
-                               "WHERE (ztokenname LIKE '%1%' ESCAPE '\\' %3) %2 "
-                               "ORDER BY ztokenname COLLATE NOCASE LIMIT 100")
-                    .arg(curQuery, notQuery, subNames.arg("ztokenname", curQuery));
-        }
-
-        QSqlQuery query(queryStr, database());
-        while (query.next()) {
-            const QString itemName = query.value(0).toString();
-            QString path = query.value(2).toString();
-            if (m_type == Docset::Type::ZDash) {
-                const QString anchor = query.value(3).toString();
-                if (!anchor.isEmpty())
-                    path += QLatin1Char('#') + anchor;
-            }
-
-            // TODO: Third should be type
-            results.append(SearchResult{itemName, QString(),
-                                        parseSymbolType(query.value(1).toString()),
-                                        const_cast<Docset *>(this), path, sanitizedQuery});
-        }
-
-        if (withSubStrings)
-            break;
-        withSubStrings = true;  // try again searching for substrings
+    int index = result.indexOf(query.query());
+    if (index == 0 || Docset::endsWithSeparator(result, index)) {
+        score -= result.size() - query.query().size() - index + Docset::separators(result, index);
+    } else {
+        score -= result.size() - query.query().size() + 2;
     }
 
-    return results;
+    return std::max(1, score);
+}
+
+QList<SearchResult> Docset::search(const QString &rawQuery, const CancellationToken &token) const
+{
+    return m_searchStrategy->search(rawQuery, token);
 }
 
 QList<SearchResult> Docset::relatedLinks(const QUrl &url) const
@@ -359,7 +398,7 @@ QList<SearchResult> Docset::relatedLinks(const QUrl &url) const
 
         results.append(SearchResult{sectionName, QString(),
                                     parseSymbolType(query.value(1).toString()),
-                                    const_cast<Docset *>(this), sectionPath, QString()});
+                                    const_cast<Docset *>(this), sectionPath, QString(), 0});
     }
 
     if (results.size() == 1)
@@ -381,7 +420,7 @@ void Docset::loadMetadata()
     if (!dir.exists(QStringLiteral("meta.json")))
         return;
 
-    QScopedPointer<QFile> file(new QFile(dir.filePath(QStringLiteral("meta.json"))));
+    std::unique_ptr<QFile> file(new QFile(dir.filePath(QStringLiteral("meta.json"))));
     if (!file->open(QIODevice::ReadOnly))
         return;
 

--- a/src/registry/docsetregistry.cpp
+++ b/src/registry/docsetregistry.cpp
@@ -98,6 +98,7 @@ Docset *DocsetRegistry::docset(const QString &name) const
 
 Docset *DocsetRegistry::docset(int index) const
 {
+    /// TODO: sort docsets
     if (index < 0 || index >= m_docsets.size())
         return nullptr;
     return (m_docsets.cbegin() + index).value();

--- a/src/registry/docsetregistry.h
+++ b/src/registry/docsetregistry.h
@@ -56,6 +56,9 @@ public:
     void search(const QString &query, const CancellationToken &token);
     const QList<SearchResult> &queryResults();
 
+    /// The number of results that should be retuned by the search.
+    static const int MaxResults = 100;
+
 public slots:
     void addDocset(const QString &path);
 

--- a/src/registry/docsetsearchstrategy.cpp
+++ b/src/registry/docsetsearchstrategy.cpp
@@ -1,3 +1,26 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Oleg Shparber
+** Copyright (C) 2013-2014 Jerzy Kozera
+** Contact: http://zealdocs.org/contact.html
+**
+** This file is part of Zeal.
+**
+** Zeal is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** Zeal is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Zeal. If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
 #include "docsetsearchstrategy.h"
 
 using namespace Zeal;

--- a/src/registry/docsetsearchstrategy.cpp
+++ b/src/registry/docsetsearchstrategy.cpp
@@ -1,0 +1,8 @@
+#include "docsetsearchstrategy.h"
+
+using namespace Zeal;
+
+DocsetSearchStrategy::DocsetSearchStrategy()
+{
+}
+

--- a/src/registry/docsetsearchstrategy.h
+++ b/src/registry/docsetsearchstrategy.h
@@ -1,5 +1,30 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Oleg Shparber
+** Copyright (C) 2013-2014 Jerzy Kozera
+** Contact: http://zealdocs.org/contact.html
+**
+** This file is part of Zeal.
+**
+** Zeal is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** Zeal is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Zeal. If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
 #ifndef DOCSETSEARCHSTRATEGY_H
 #define DOCSETSEARCHSTRATEGY_H
+
+#include "cancellationtoken.h"
 
 #include <QString>
 #include <QList>
@@ -14,7 +39,11 @@ class DocsetSearchStrategy
 {
 public:
     DocsetSearchStrategy();
-    virtual QList<SearchResult> search(const QString &query, const CancellationToken &token) const = 0;
+    virtual QList<SearchResult> search(const QString &query, const CancellationToken &token) = 0;
+
+    /// Used to filter out cached results.
+    virtual bool validResult(const QString &query, const SearchResult &previousResult,
+                             SearchResult &result) const = 0;
 };
 
 }

--- a/src/registry/docsetsearchstrategy.h
+++ b/src/registry/docsetsearchstrategy.h
@@ -1,0 +1,22 @@
+#ifndef DOCSETSEARCHSTRATEGY_H
+#define DOCSETSEARCHSTRATEGY_H
+
+#include <QString>
+#include <QList>
+
+namespace Zeal {
+
+struct CancellationToken;
+struct SearchResult;
+
+/// This class contains search related methods for docsets.
+class DocsetSearchStrategy
+{
+public:
+    DocsetSearchStrategy();
+    virtual QList<SearchResult> search(const QString &query, const CancellationToken &token) const = 0;
+};
+
+}
+
+#endif // DOCSETSEARCHSTRATEGY_H

--- a/src/registry/searchresult.cpp
+++ b/src/registry/searchresult.cpp
@@ -42,3 +42,10 @@ bool SearchResult::operator<(const SearchResult &r) const
 
     return QString::compare(parentName, r.parentName, Qt::CaseInsensitive) < 0;
 }
+
+SearchResult SearchResult::withScore(int newScore) const
+{
+    return SearchResult({name, parentName, type,
+                         docset, path, query,
+                         newScore});
+}

--- a/src/registry/searchresult.cpp
+++ b/src/registry/searchresult.cpp
@@ -27,6 +27,9 @@ using namespace Zeal;
 
 bool SearchResult::operator<(const SearchResult &r) const
 {
+    if (score != r.score)
+        return score > r.score;
+
     const bool lhsStartsWithQuery = name.startsWith(query, Qt::CaseInsensitive);
     const bool rhsStartsWithQuery = r.name.startsWith(query, Qt::CaseInsensitive);
 

--- a/src/registry/searchresult.h
+++ b/src/registry/searchresult.h
@@ -46,6 +46,8 @@ struct SearchResult
     int score;
 
     bool operator<(const SearchResult &r) const;
+
+    SearchResult withScore(int newScore) const;
 };
 
 } // namespace Zeal

--- a/src/registry/searchresult.h
+++ b/src/registry/searchresult.h
@@ -43,6 +43,8 @@ struct SearchResult
     // TODO: Remove
     QString query;
 
+    int score;
+
     bool operator<(const SearchResult &r) const;
 };
 


### PR DESCRIPTION
Improves search performance. Returns results **without any observable delay** when searching through large docsets (including .NET and QT).

Cancels previous incomplete searches.
Defers browser url loading.
Adds caching of previous searches. Filters through the existing result list to avoid searching through the entire docset.
Adds parallel searching of docsets.

Depends on #459 in order to correctly display ToC after ESC is pressed.
