### PR TITLE
ui: Prevent QWebEnginePage from stealing focus from the search input

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -407,6 +407,9 @@ void MainWindow::queryCompleted()
     m_treeViewClicked = true;
     ui->treeView->setCurrentIndex(m_searchState->zealSearch->index(0, 0, QModelIndex()));
     ui->treeView->activated(ui->treeView->currentIndex());
+#if USE_WEBENGINE
+    ui->lineEdit->setFocus(Qt::MouseFocusReason);
+#endif
 }
 
 void MainWindow::goToTab(int index)


### PR DESCRIPTION
this fix the problem of losing focus instantly when typing