### PR TITLE
ui: Fix rename tocView to tocListView

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -326,7 +326,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
 
 #ifdef Q_OS_OSX
     ui->treeView->setAttribute(Qt::WA_MacShowFocusRect, false);
-    ui->tocView->setAttribute(Qt::WA_MacShowFocusRect, false);
+    ui->tocListView->setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
 
     if (m_settings->checkForUpdate)


### PR DESCRIPTION
Fix an incomplete rename causing a compiler error.