### PR TITLE
Parse query given the list of known docset keywords

### DIFF
--- a/src/registry/docset.cpp
+++ b/src/registry/docset.cpp
@@ -241,11 +241,10 @@ const QMap<QString, QString> &Docset::symbols(const QString &symbolType) const
     return m_symbols[symbolType];
 }
 
-QList<SearchResult> Docset::search(const QString &query) const
+QList<SearchResult> Docset::search(const SearchQuery &searchQuery) const
 {
     QList<SearchResult> results;
 
-    const SearchQuery searchQuery = SearchQuery::fromString(query);
     const QString sanitizedQuery = searchQuery.sanitizedQuery();
 
     if (searchQuery.hasKeywords() && !searchQuery.hasKeywords(m_keywords))

--- a/src/registry/docset.h
+++ b/src/registry/docset.h
@@ -31,6 +31,7 @@
 
 namespace Zeal {
 
+class SearchQuery;
 struct SearchResult;
 
 class Docset
@@ -59,7 +60,7 @@ public:
 
     const QMap<QString, QString> &symbols(const QString &symbolType) const;
 
-    QList<SearchResult> search(const QString &query) const;
+    QList<SearchResult> search(const SearchQuery &query) const;
     QList<SearchResult> relatedLinks(const QUrl &url) const;
 
     // FIXME: This is an ugly workaround before we have a proper docset sources implementation

--- a/src/registry/docsetregistry.cpp
+++ b/src/registry/docsetregistry.cpp
@@ -147,7 +147,7 @@ void DocsetRegistry::_runQuery(const QString &queryStr)
 
 SearchQuery DocsetRegistry::getSearchQuery(const QString &queryStr) const
 {
-    return SearchQuery::fromString(queryStr);
+    return SearchQuery::fromString(queryStr, completions());
 }
 
 QStringList DocsetRegistry::completions() const

--- a/src/registry/docsetregistry.cpp
+++ b/src/registry/docsetregistry.cpp
@@ -23,6 +23,7 @@
 
 #include "docsetregistry.h"
 
+#include "searchquery.h"
 #include "searchresult.h"
 
 #include <QDir>
@@ -131,8 +132,9 @@ void DocsetRegistry::search(const QString &query)
     QMetaObject::invokeMethod(this, "_runQuery", Qt::QueuedConnection, Q_ARG(QString, query));
 }
 
-void DocsetRegistry::_runQuery(const QString &query)
+void DocsetRegistry::_runQuery(const QString &queryStr)
 {
+    SearchQuery query = getSearchQuery(queryStr);
     QList<SearchResult> results;
 
     for (Docset *docset : docsets())
@@ -141,6 +143,11 @@ void DocsetRegistry::_runQuery(const QString &query)
     std::sort(results.begin(), results.end());
 
     emit queryCompleted(results);
+}
+
+SearchQuery DocsetRegistry::getSearchQuery(const QString &queryStr) const
+{
+    return SearchQuery::fromString(queryStr);
 }
 
 // Recursively finds and adds all docsets in a given directory.

--- a/src/registry/docsetregistry.cpp
+++ b/src/registry/docsetregistry.cpp
@@ -150,6 +150,19 @@ SearchQuery DocsetRegistry::getSearchQuery(const QString &queryStr) const
     return SearchQuery::fromString(queryStr);
 }
 
+QStringList DocsetRegistry::completions() const
+{
+    QStringList completionsList;
+    for (const Docset * const docset: docsets()) {
+        if (docset->keywords().isEmpty())
+            continue;
+
+        completionsList << docset->keywords().first() + QLatin1Char(':');
+    }
+
+    return completionsList;
+}
+
 // Recursively finds and adds all docsets in a given directory.
 void DocsetRegistry::addDocsetsFromFolder(const QString &path)
 {

--- a/src/registry/docsetregistry.h
+++ b/src/registry/docsetregistry.h
@@ -55,6 +55,7 @@ public:
 
     void search(const QString &query);
     SearchQuery getSearchQuery(const QString &queryStr) const;
+    QStringList completions() const;
 
 public slots:
     void addDocset(const QString &path);

--- a/src/registry/docsetregistry.h
+++ b/src/registry/docsetregistry.h
@@ -32,6 +32,7 @@ class QThread;
 
 namespace Zeal {
 
+class SearchQuery;
 struct SearchResult;
 
 class DocsetRegistry : public QObject
@@ -53,6 +54,7 @@ public:
     QList<Docset *> docsets() const;
 
     void search(const QString &query);
+    SearchQuery getSearchQuery(const QString &queryStr) const;
 
 public slots:
     void addDocset(const QString &path);
@@ -65,7 +67,7 @@ signals:
 
 private slots:
     void _addDocset(const QString &path);
-    void _runQuery(const QString &query);
+    void _runQuery(const QString &queryStr);
 
 private:
     void addDocsetsFromFolder(const QString &path);

--- a/src/registry/searchquery.cpp
+++ b/src/registry/searchquery.cpp
@@ -153,14 +153,15 @@ QString SearchQuery::sanitizedQuery() const
 
 QDataStream &Zeal::operator<<(QDataStream &out, const SearchQuery &query)
 {
-    out << query.toString();
+    out << query.query() << query.keywords().join(keywordSeparator);
     return out;
 }
 
 QDataStream &Zeal::operator>>(QDataStream &in, SearchQuery &query)
 {
-    QString str;
-    in >> str;
-    query = SearchQuery::fromString(str, QStringList());
+    QString queryStr;
+    QString keywordStr;
+    in >> queryStr >> keywordStr;
+    query = SearchQuery(queryStr, keywordStr.split(keywordSeparator));
     return in;
 }

--- a/src/registry/searchquery.h
+++ b/src/registry/searchquery.h
@@ -53,7 +53,7 @@ public:
     /// Multiple docsets are supported using the ',' character:
     ///   "java,android:setTypeFa #=> docsetFilters = ["java", "android"], coreQuery = "setTypeFa"
 
-    static SearchQuery fromString(const QString &str);
+    static SearchQuery fromString(const QString &str, const QStringList &validKeywords);
 
     QString toString() const;
 
@@ -79,6 +79,8 @@ public:
     QString sanitizedQuery() const;
 
 private:
+    static QStringList tryGetKeywords(const QString &keywordStr, const QStringList &validKeywords);
+
     QString m_query;
     QStringList m_keywords;
     QString m_keywordPrefix;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -185,12 +185,13 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
 
     // treeView and lineEdit
     ui->lineEdit->setTreeView(ui->treeView);
+    ui->lineEdit->setRegistry(app->docsetRegistry());
     ui->lineEdit->setFocus();
     setupSearchBoxCompletions();
     SearchItemDelegate *delegate = new SearchItemDelegate(ui->treeView);
     delegate->setDecorationRoles({Zeal::SearchModel::DocsetIconRole, Qt::DecorationRole});
-    connect(ui->lineEdit, &QLineEdit::textChanged, [delegate](const QString &text) {
-        delegate->setHighlight(Zeal::SearchQuery::fromString(text).query());
+    connect(ui->lineEdit, &QLineEdit::textChanged, [delegate, app](const QString &text) {
+        delegate->setHighlight(app->docsetRegistry()->getSearchQuery(text).query());
     });
     ui->treeView->setItemDelegate(delegate);
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -535,15 +535,7 @@ void MainWindow::reloadTabState()
 // Sets up the search box autocompletions.
 void MainWindow::setupSearchBoxCompletions()
 {
-    QStringList completions;
-    for (const Docset * const docset: m_application->docsetRegistry()->docsets()) {
-        if (docset->keywords().isEmpty())
-            continue;
-
-        completions << docset->keywords().first() + QLatin1Char(':');
-    }
-
-    ui->lineEdit->setCompletions(completions);
+    ui->lineEdit->setCompletions(m_application->docsetRegistry()->completions());
 }
 
 void MainWindow::setupTabBar()

--- a/src/ui/widgets/searchedit.cpp
+++ b/src/ui/widgets/searchedit.cpp
@@ -23,6 +23,7 @@
 
 #include "searchedit.h"
 
+#include "registry/docsetregistry.h"
 #include "registry/searchquery.h"
 
 #include <QCompleter>
@@ -46,6 +47,11 @@ void SearchEdit::setTreeView(QTreeView *view)
 {
     m_treeView = view;
     m_focusing = false;
+}
+
+void SearchEdit::setRegistry(Zeal::DocsetRegistry *registry)
+{
+    m_registry = registry;
 }
 
 // Makes the line edit use autocompletions.
@@ -154,7 +160,10 @@ QString SearchEdit::currentCompletion(const QString &text) const
 
 int SearchEdit::queryStart() const
 {
-    const Zeal::SearchQuery currentQuery = Zeal::SearchQuery::fromString(text());
+    const Zeal::SearchQuery currentQuery = m_registry != nullptr
+        ? m_registry->getSearchQuery(text())
+        : Zeal::SearchQuery::fromString(text(), QStringList());
+
     // Keep the filter for the first Escape press
     return currentQuery.query().isEmpty() ? 0 : currentQuery.keywordPrefixSize();
 }

--- a/src/ui/widgets/searchedit.h
+++ b/src/ui/widgets/searchedit.h
@@ -31,6 +31,13 @@ class QEvent;
 class QLabel;
 class QTreeView;
 
+namespace Zeal {
+
+class DocsetRegistry;
+class SearchQuery;
+
+}
+
 class SearchEdit : public QLineEdit
 {
     Q_OBJECT
@@ -38,6 +45,7 @@ public:
     explicit SearchEdit(QWidget *parent = nullptr);
 
     void setTreeView(QTreeView *view);
+    void setRegistry(Zeal::DocsetRegistry *registry);
     void clearQuery();
     void selectQuery();
     void setCompletions(const QStringList &completions);
@@ -55,6 +63,7 @@ private:
     QString currentCompletion(const QString &text) const;
     int queryStart() const;
 
+    Zeal::DocsetRegistry *m_registry;
     QCompleter *m_prefixCompleter = nullptr;
     QTreeView *m_treeView = nullptr;
     QLabel *m_completionLabel = nullptr;


### PR DESCRIPTION
This is the first in order to implement docset keyword groups and custom docset keywords.

Adds a parameter to `SearchQuery::fromString` that has a list of available keywords.
Replaces all places where the query is constructed with the call to docsetregistry that is aware of currently available keywords.

In effect `prefix1:` will only be treated as a keyword prefix if it matches a valid keyword.
For example `std:` is not treated as a keyword since no docset has a name std.
In fact `cpp:` will not be treated as a keyword until the c++ docset is installed.
