### PR TITLE
Defer opening the first query result

### DIFF
--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -90,6 +90,7 @@ protected:
 
 private slots:
     void applySettings();
+    void deferOpenDocset(const QModelIndex &index);
     void openDocset(const QModelIndex &index);
     void queryCompleted();
     void closeTab(int index = -1);
@@ -121,6 +122,8 @@ private:
 
     QMenu *m_backMenu = nullptr;
     QMenu *m_forwardMenu = nullptr;
+
+    QTimer *m_deferOpenUrl;
 
     QxtGlobalShortcut *m_globalShortcut = nullptr;
 


### PR DESCRIPTION
Add a timer that defers the browser opening.
This prevents from loading many pages as a user types the query.