### PR TITLE
Fix crash on quit (closes #577)

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -471,6 +471,7 @@ MainWindow::~MainWindow()
     m_settings->windowGeometry = saveGeometry();
 
     delete ui;
+    delete ui->webView;
     qDeleteAll(m_tabStates);
 }
 


### PR DESCRIPTION
Seems like after qDeleteAll webView still tries to do some activity with current webPage even after it's deleted.
Probably this is good. It's always possible to just use
 ```cpp 
ui->webView->close();
``` 
if you want deletion to be handled by MainWindow itself.