### PR TITLE
Fix appindicator crashes

### DIFF
--- a/qmake/common.pri
+++ b/qmake/common.pri
@@ -63,3 +63,10 @@ CONFIG(zeal_portable) {
 unix:!macx {
     isEmpty(PREFIX): PREFIX = /usr
 }
+
+unix:!macx:packagesExist(appindicator-0.1) {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += appindicator-0.1 gtk+-2.0
+    DEFINES += USE_APPINDICATOR
+    message("AppIndicator support: Yes.")
+}

--- a/src/libs/ui/ui.pri
+++ b/src/libs/ui/ui.pri
@@ -2,13 +2,6 @@ ZEAL_LIB_NAME = Ui
 
 QT += widgets
 
-unix:!macx:packagesExist(appindicator-0.1) {
-    CONFIG += link_pkgconfig
-    PKGCONFIG += appindicator-0.1 gtk+-2.0
-    DEFINES += USE_APPINDICATOR
-    message("AppIndicator support: Yes.")
-}
-
 # QxtGlobalShortcut dependencies
 unix:!macx {
     QT += x11extras


### PR DESCRIPTION
Missing USE_APPINDICATOR in libs/core/ was causing the MainWindow class declaration to be truncated, thus causing memory corruption when later used with the full definition in libs/ui/.