### PR TITLE
core: Reject no-scheme URLs on a local file system (fixes #532)

### DIFF
--- a/src/libs/core/application.cpp
+++ b/src/libs/core/application.cpp
@@ -23,6 +23,7 @@
 #include "application.h"
 
 #include "extractor.h"
+#include "networkaccessmanager.h"
 #include "settings.h"
 
 #include <registry/docsetregistry.h>
@@ -35,7 +36,6 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMetaObject>
-#include <QNetworkAccessManager>
 #include <QNetworkProxy>
 #include <QNetworkReply>
 #include <QScopedPointer>
@@ -59,7 +59,7 @@ Application::Application(QObject *parent) :
     m_instance = this;
 
     m_settings = new Settings(this);
-    m_networkManager = new QNetworkAccessManager(this);
+    m_networkManager = new NetworkAccessManager(this);
 
     // Extractor setup
     m_extractorThread = new QThread(this);

--- a/src/libs/core/networkaccessmanager.cpp
+++ b/src/libs/core/networkaccessmanager.cpp
@@ -1,0 +1,44 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Oleg Shparber
+** Contact: https://go.zealdocs.org/l/contact
+**
+** This file is part of Zeal.
+**
+** Zeal is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** Zeal is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Zeal. If not, see <https://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "networkaccessmanager.h"
+
+#include <QNetworkRequest>
+
+using namespace Zeal::Core;
+
+NetworkAccessManager::NetworkAccessManager(QObject *parent)
+    : QNetworkAccessManager(parent)
+{
+}
+
+QNetworkReply *NetworkAccessManager::createRequest(QNetworkAccessManager::Operation op,
+                                             const QNetworkRequest &request,
+                                             QIODevice *outgoingData)
+{
+    // Detect URLs without schema, and prevent them from being requested on a local filesytem.
+    const QUrl url = request.url();
+    if (url.scheme() == QLatin1String("file") && !url.host().isEmpty())
+        return QNetworkAccessManager::createRequest(GetOperation, QNetworkRequest(), outgoingData);
+
+    return QNetworkAccessManager::createRequest(op, request, outgoingData);
+}

--- a/src/libs/core/networkaccessmanager.h
+++ b/src/libs/core/networkaccessmanager.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Oleg Shparber
+** Contact: https://go.zealdocs.org/l/contact
+**
+** This file is part of Zeal.
+**
+** Zeal is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** Zeal is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Zeal. If not, see <https://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#ifndef ZEAL_CORE_NETWORKACCESSMANAGER_H
+#define ZEAL_CORE_NETWORKACCESSMANAGER_H
+
+#include <QNetworkAccessManager>
+
+namespace Zeal {
+namespace Core {
+
+class NetworkAccessManager : public QNetworkAccessManager
+{
+    Q_OBJECT
+public:
+    NetworkAccessManager(QObject *parent = nullptr);
+
+protected:
+    QNetworkReply *createRequest(Operation op, const QNetworkRequest &request,
+                                 QIODevice *outgoingData = nullptr) override;
+};
+
+} // namespace Core
+} // namespace Zeal
+
+#endif // ZEAL_CORE_NETWORKACCESSMANAGER_H


### PR DESCRIPTION
This change adds back a custom network access manager, that was removed
as a fix for #474. Although this time the URL validation logic is much
more simple.