### PR TITLE
ui: Fix 'Select All' selection in the docset manager

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -98,7 +98,7 @@ DocsetsDialog::DocsetsDialog(Core::Application *app, QWidget *parent) :
             [this, selectionModel]() {
         ui->removeDocsetsButton->setEnabled(selectionModel->hasSelection());
 
-        for (const QModelIndex &index : selectionModel->selectedIndexes()) {
+        for (const QModelIndex &index : selectionModel->selectedRows()) {
             if (index.data(ListModel::UpdateAvailableRole).toBool()) {
                 ui->updateSelectedDocsetsButton->setEnabled(true);
                 return;
@@ -135,7 +135,7 @@ DocsetsDialog::DocsetsDialog(Core::Application *app, QWidget *parent) :
 
     selectionModel = ui->availableDocsetList->selectionModel();
     connect(selectionModel, &QItemSelectionModel::selectionChanged, [this, selectionModel]() {
-        for (const QModelIndex &index : selectionModel->selectedIndexes()) {
+        for (const QModelIndex &index : selectionModel->selectedRows()) {
             if (!index.data(ProgressItemDelegate::ShowProgressRole).toBool()) {
                 ui->downloadDocsetsButton->setEnabled(true);
                 return;
@@ -217,7 +217,7 @@ void DocsetsDialog::addDashFeed()
 
 void DocsetsDialog::updateSelectedDocsets()
 {
-    for (const QModelIndex &index : ui->installedDocsetList->selectionModel()->selectedIndexes()) {
+    for (const QModelIndex &index : ui->installedDocsetList->selectionModel()->selectedRows()) {
         if (!index.data(Registry::ListModel::UpdateAvailableRole).toBool())
             continue;
 
@@ -245,7 +245,7 @@ void DocsetsDialog::removeSelectedDocsets()
 
     int ret;
 
-    const QModelIndexList selectedIndexes = selectonModel->selectedIndexes();
+    const QModelIndexList selectedIndexes = selectonModel->selectedRows();
     if (selectedIndexes.size() == 1) {
         const QString docsetTitle = selectedIndexes.first().data().toString();
         ret = QMessageBox::question(this, QStringLiteral("Zeal"),
@@ -286,7 +286,7 @@ void DocsetsDialog::updateDocsetFilter(const QString &filterString)
 void DocsetsDialog::downloadSelectedDocsets()
 {
     QItemSelectionModel *selectionModel = ui->availableDocsetList->selectionModel();
-    for (const QModelIndex &index : selectionModel->selectedIndexes()) {
+    for (const QModelIndex &index : selectionModel->selectedRows()) {
         selectionModel->select(index, QItemSelectionModel::Deselect);
 
         // Do nothing if a download is already in progress.
@@ -756,7 +756,7 @@ void DocsetsDialog::resetProgress()
     ui->addFeedButton->setEnabled(true);
     QItemSelectionModel *selectionModel = ui->installedDocsetList->selectionModel();
     bool hasSelectedUpdates = false;
-    for (const QModelIndex &index : selectionModel->selectedIndexes()) {
+    for (const QModelIndex &index : selectionModel->selectedRows()) {
         if (index.data(Registry::ListModel::UpdateAvailableRole).toBool()) {
             hasSelectedUpdates = true;
             break;


### PR DESCRIPTION
This fixes duplicated items in selection models because of multiple
columns.