### PR TITLE
ProgressItemDelegate fixes

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -127,7 +127,7 @@ DocsetsDialog::DocsetsDialog(Core::Application *app, QWidget *parent) :
         ui->availableDocsetList->selectionModel()->select(index, QItemSelectionModel::Deselect);
 
         QAbstractItemModel *model = ui->availableDocsetList->model();
-        model->setData(index, tr("Downloading: %p%"), ProgressItemDelegate::FormatRole);
+        model->setData(index, tr("Downloading"), ProgressItemDelegate::FormatRole);
         model->setData(index, 0, ProgressItemDelegate::ValueRole);
         model->setData(index, true, ProgressItemDelegate::ShowProgressRole);
 
@@ -294,7 +294,7 @@ void DocsetsDialog::downloadSelectedDocsets()
             continue;
 
         QAbstractItemModel *model = ui->availableDocsetList->model();
-        model->setData(index, tr("Downloading: %p%"), ProgressItemDelegate::FormatRole);
+        model->setData(index, tr("Downloading"), ProgressItemDelegate::FormatRole);
         model->setData(index, 0, ProgressItemDelegate::ValueRole);
         model->setData(index, true, ProgressItemDelegate::ShowProgressRole);
 
@@ -425,7 +425,7 @@ void DocsetsDialog::downloadCompleted()
         QListWidgetItem *item = findDocsetListItem(docsetName);
         if (item) {
             item->setData(ProgressItemDelegate::ValueRole, 0);
-            item->setData(ProgressItemDelegate::FormatRole, tr("Installing: %p%"));
+            item->setData(ProgressItemDelegate::FormatRole, tr("Installing"));
         }
 
         m_application->extract(tmpFile->fileName(), m_application->settings()->docsetPath,

--- a/src/libs/ui/progressitemdelegate.h
+++ b/src/libs/ui/progressitemdelegate.h
@@ -42,7 +42,7 @@ public:
                const QModelIndex &index) const override;
 
 private:
-    static const int progressBarWidth = 150;
+    static const int progressBarWidth = 250;
 };
 
 #endif // PROGRESSITEMDELEGATE_H


### PR DESCRIPTION
The patch fixes delegate's progress bar painting. Old version don't show progress bar if text width (depends on font size) is close to allowed maximum (`progressBarWidth` constant value is too small) and also paint progress bar with direct using of `QProgressBar` class - this leads to painting default widget background color (instead needed transparent).

New version fixes these problems by using `QStyleOptionProgressBar` class and increasing `progressBarWidth` constant value.