### PR TITLE
Automatically load selected docset on keyboard selection without enter or click

### DIFF
--- a/src/libs/ui/mainwindow.h
+++ b/src/libs/ui/mainwindow.h
@@ -28,6 +28,7 @@
 
 class QxtGlobalShortcut;
 
+class QItemSelection;
 class QModelIndex;
 class QSystemTrayIcon;
 class QTabBar;
@@ -79,6 +80,8 @@ protected:
 private slots:
     void applySettings();
     void openDocset(const QModelIndex &index);
+    void openAndFocusDocset(const QModelIndex &index);
+    void openDocsetDelayed(const QModelIndex &index);
     void queryCompleted();
     void closeTab(int index = -1);
     void moveTab(int from, int to);


### PR DESCRIPTION
This fixes one of my main peeves working between Dash and Zeal. Dash automatically loads the selected docset in the tree when changing the selection with the keyboard. Up until now, Zeal has required enter to be pressed to load a docset selected with the keyboard, which additionally moved focus away from the tree.

That is, in Dash the workflow is:

- search something
- use up/down arrows to move to relevant looking item
- [docset loads after a small delay]
- use up/down arrows to move to a different item
- ...

While in Zeal this has been:

- search something
- use up/down arrows to move to an item
- press enter to load selected item
- [focus moves to web view, keyboard can no longer change selection]
- use mouse to pick a different item or to focus tree again
- ...

This commit implements behaviour similar to Dash:

![zeal-update](https://user-images.githubusercontent.com/2230769/28210890-e70270a2-68ed-11e7-9aef-6fbaf06c5628.gif)

Notable changes:

- Focus is no longer lost (shifted to the web view) when a docset is loaded unless it is actively selected with enter or a click. This is mostly to maintain the existing behaviour for these actions. Personally I feel clicking an item should leave focus in the tree for further keyboard selection.

- The timeout for searching now serves as a general purpose delayed docset load timeout. This limits the typing and selection delays to the same value, but the 400ms currently used seems to work well in both cases.

- An "active" load (click/enter) overrides any delayed load (keyboard selection)

Other notes:

- Dash appears to throttle loading rather than use a fixed delay. Throttling results in a slightly nicer experience as changing the selection slowly loads the new selection without delay.