### PR TITLE
Small changes to fix build on CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ After installing Zeal, you need to download docsets. Go to *Tools->Docsets*, sel
 ### Requirements
 * [Qt](https://www.qt.io/) version 5.5.1 or above. Required modules: Qt WebKit Widgets, Qt X11 Extras (X11 only).
 * [libarchive](http://libarchive.org/).
+* [sqlite3](https://www.sqlite.org/).
 * X11 only: `xcb-util-keysyms`.
 
 To compile Zeal run `qmake` and then `make`. Linux users can install Zeal with `make install` command.

--- a/src/libs/core/filemanager.cpp
+++ b/src/libs/core/filemanager.cpp
@@ -26,7 +26,7 @@
 #include <QFutureWatcher>
 #include <QLoggingCategory>
 
-#include <QtConcurrent>
+#include <QtConcurrent/QtConcurrent>
 
 using namespace Zeal::Core;
 


### PR DESCRIPTION
On CentOS 7, `<QtConcurrent>` is not available; it needs to be `<QtConcurrent/QtConcurrent>`. This is already used in `docsetregistry.cpp`; only `filemanager.cpp` needed changing.

I also updated the readme to mention the sqlite dependency.