### PR TITLE
Add a CTRL+L shortcut to bring focus to the search field

### DIFF
--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -307,6 +307,12 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
     });
     ui->treeView->setItemDelegate(delegate);
 
+    QAction* goToLineEditAction = new QAction(ui->lineEdit);
+    goToLineEditAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_L));
+    goToLineEditAction->setShortcutContext(Qt::ApplicationShortcut);
+    ui->lineEdit->addAction(goToLineEditAction);
+    connect(goToLineEditAction, &QAction::triggered, this, [this]() { ui->lineEdit->setFocus(); });
+
     ui->tocListView->setItemDelegate(new SearchItemDelegate(ui->tocListView));
     connect(ui->tocSplitter, &QSplitter::splitterMoved, this, [this]() {
         m_settings->tocSplitterState = ui->tocSplitter->saveState();


### PR DESCRIPTION
This PR adds the ability to press Ctrl-L and go to the search box (lineEdit in mainwindow.ui)

This is an established shortcut with browser ("location bar") and also used in Dash.