### PR TITLE
assets: Add FreeDesktop application data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Makefile*
 
 # CMake
 CMakeLists.txt.user
+
+# build artifacts
+zeal.appdata.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 project(Zeal VERSION 0.6.0)
+string(TIMESTAMP RELEASE_DATE "%Y-%m-%d" UTC)
 
 # Project information.
 if(APPLE)

--- a/assets/freedesktop/CMakeLists.txt
+++ b/assets/freedesktop/CMakeLists.txt
@@ -12,7 +12,15 @@ if(UNIX AND NOT APPLE)
                       DESTINATION ${KDE_INSTALL_ICONDIR}
     )
 
-    # TODO: Generate via zeal.desktop.in.
+    configure_file(
+        zeal.appdata.xml.in
+        zeal.appdata.xml
+    )
+
+    install(FILES "zeal.appdata.xml"
+            DESTINATION ${KDE_INSTALL_METAINFODIR}
+    )
+
     install(FILES "zeal.desktop"
             DESTINATION ${KDE_INSTALL_APPDIR}
     )

--- a/assets/freedesktop/zeal.appdata.xml.in
+++ b/assets/freedesktop/zeal.appdata.xml.in
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>io.zealdocs.Zeal.desktop</id>
+  <name>Zeal</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <summary>Documentation browser</summary>
+  <description>
+    <p>Zeal is a simple offline documentation browser inspired by Dash.</p>
+  </description>
+  <url type="homepage">https://zealdocs.org/</url>
+  <url type="bugtracker">https://github.com/zealdocs/zeal/issues</url>
+  <url type="help">https://zealdocs.org/usage.html</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://i.imgur.com/qBkZduS.png</image>
+    </screenshot>
+  </screenshots>
+  <provides>
+    <id>zeal.desktop</id>
+  </provides>
+  <releases>
+    <release date="${RELEASE_DATE}" version="${Zeal_VERSION}">
+    </release>
+  </releases>
+  <update_contact>zeal@zealdocs.org</update_contact>
+</component>


### PR DESCRIPTION
As part of improvements in preparation for flathub submission, this
change-set adds application metadata.

Closes: #911 