### PR TITLE
Background fix for dark mode

### DIFF
--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -879,7 +879,7 @@ void MainWindow::applySettings()
         removeTrayIcon();
 
     // Content
-    QByteArray ba;
+    QByteArray ba = QByteArrayLiteral("body { background-color: white; }");
     if (m_settings->darkModeEnabled) {
         QScopedPointer<QFile> file(new QFile(DarkModeCssUrl));
         if (file->open(QIODevice::ReadOnly)) {


### PR DESCRIPTION
If HTML page doesn't set background ("Bash" docset for example) then it will be theme-dependent. When light theme is used with disabled dark mode everything works well - we have black text on white background. When light theme is used with enabled dark mode everything is fine again - we have light text on dark background. But when dark theme is used with disabled dark mode we will see black text on dark background (tested on Qt 5.11). Therefore when our dark mode CSS is applied we will see light text on light background :( So we should always set default background color to white - it will be properly processed both for light and dark themes.

OLD version:
![screenshot_20180625_202236](https://user-images.githubusercontent.com/5655233/41850720-33f7b9f0-78b8-11e8-9fe8-c95171d4b725.png)

NEW version:
![screenshot_20180625_202401](https://user-images.githubusercontent.com/5655233/41850734-3a623ad6-78b8-11e8-9b81-0ac6c4336fe8.png)
