### PR TITLE
 Added preference to selectively disable JavaScript in QWebView 

### DIFF
--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -137,6 +137,7 @@ void Settings::load()
     externalLinkPolicy = settings->value(QStringLiteral("external_link_policy"),
                                          QVariant::fromValue(ExternalLinkPolicy::Ask)).value<ExternalLinkPolicy>();
     isSmoothScrollingEnabled = settings->value(QStringLiteral("smooth_scrolling"), false).toBool();
+    isJavaScriptDisabled = settings->value(QStringLiteral("disable_js"), false).toBool();
     isAdDisabled = settings->value(QStringLiteral("disable_ad"), false).toBool();
     settings->endGroup();
 
@@ -216,6 +217,7 @@ void Settings::save()
     settings->setValue(QStringLiteral("custom_css_file"), customCssFile);
     settings->setValue(QStringLiteral("external_link_policy"), QVariant::fromValue(externalLinkPolicy));
     settings->setValue(QStringLiteral("smooth_scrolling"), isSmoothScrollingEnabled);
+    settings->setValue(QStringLiteral("disable_js"), isJavaScriptDisabled);
     settings->setValue(QStringLiteral("disable_ad"), isAdDisabled);
     settings->endGroup();
 

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -81,6 +81,7 @@ public:
     bool highlightOnNavigateEnabled;
     QString customCssFile;
     bool isSmoothScrollingEnabled;
+    bool isJavaScriptDisabled;
     bool isAdDisabled;
 
     // Network

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -122,6 +122,11 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
         webSettings->setFontSize(QWebSettings::MinimumFontSize, fontSize);
     });
 
+    connect(ui->disableJavaScriptCheckBox, &QCheckBox::stateChanged, this, [webSettings](int state) {
+        bool isJavaScriptDisabled = (state == Qt::Checked);
+        webSettings->setAttribute(QWebSettings::JavascriptEnabled, !isJavaScriptDisabled);
+    });
+
     loadSettings();
 }
 
@@ -214,6 +219,7 @@ void SettingsDialog::loadSettings()
     }
 
     ui->useSmoothScrollingCheckBox->setChecked(settings->isSmoothScrollingEnabled);
+    ui->disableJavaScriptCheckBox->setChecked(settings->isJavaScriptDisabled);
     ui->disableAdCheckBox->setChecked(settings->isAdDisabled);
 
     // Network Tab
@@ -281,6 +287,7 @@ void SettingsDialog::saveSettings()
     }
 
     settings->isSmoothScrollingEnabled = ui->useSmoothScrollingCheckBox->isChecked();
+    settings->isJavaScriptDisabled = ui->disableJavaScriptCheckBox->isChecked();
     settings->isAdDisabled = ui->disableAdCheckBox->isChecked();
 
     // Network Tab

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -465,7 +465,7 @@
           <item>
            <widget class="QRadioButton" name="radioExternalLinkAsk">
             <property name="text">
-             <string>&amp;Ask everytime</string>
+             <string>Ask e&amp;verytime</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -499,6 +499,13 @@
            <widget class="QCheckBox" name="useSmoothScrollingCheckBox">
             <property name="text">
              <string>Use smoo&amp;th scrolling</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="disableJavaScriptCheckBox">
+            <property name="text">
+             <string>Disable &amp;JavaScript in Web View</string>
             </property>
            </widget>
           </item>
@@ -541,7 +548,7 @@
           <item>
            <widget class="QRadioButton" name="noProxySettings">
             <property name="text">
-             <string>No proxy</string>
+             <string>No pro&amp;xy</string>
             </property>
             <property name="checked">
              <bool>false</bool>

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -465,7 +465,7 @@
           <item>
            <widget class="QRadioButton" name="radioExternalLinkAsk">
             <property name="text">
-             <string>Ask e&amp;verytime</string>
+             <string>&amp;Ask everytime</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -548,7 +548,7 @@
           <item>
            <widget class="QRadioButton" name="noProxySettings">
             <property name="text">
-             <string>No pro&amp;xy</string>
+             <string>No proxy</string>
             </property>
             <property name="checked">
              <bool>false</bool>


### PR DESCRIPTION
This is a followup to https://github.com/zealdocs/zeal/issues/999

Disabling JS on Qt Documentation fixes this issue.