### PR TITLE
Investigate TODO: QAction triggered signal doesn't connect with QToolButton animateClick slot

### DIFF
--- a/src/libs/ui/widgets/searchtoolbar.cpp
+++ b/src/libs/ui/widgets/searchtoolbar.cpp
@@ -60,8 +60,6 @@ SearchToolBar::SearchToolBar(QWebView *webView, QWidget *parent)
     // A workaround for QAbstractButton lacking support for multiple shortcuts.
     QAction *action = new QAction(m_findPreviousButton);
     action->setShortcuts(QKeySequence::FindPrevious);
-    // TODO: Investigate why direct connection does not work.
-    //connect(action, &QAction::triggered, m_findPreviousButton, &QToolButton::animateClick);
     connect(action, &QAction::triggered, this, [this]() { m_findPreviousButton->animateClick(); });
     addAction(action);
 


### PR DESCRIPTION
`QAction::triggered` has the prototype `triggered(bool checked=false)`
`QAbstractButton::animateClick` has the prototype `nimateClick(int msec=100)`

In this case, we don't set the QAction checkable boolean and its by default, `false`.
An implicit conversion of `false` to `int` occurs here. The actual signal to slot connection is also confirmed using GammaRay