### PR TITLE
Add cancel button for each of the ongoing docset downloads

### DIFF
--- a/src/libs/ui/docsetsdialog.h
+++ b/src/libs/ui/docsetsdialog.h
@@ -112,6 +112,7 @@ private:
     bool updatesAvailable() const;
 
     QNetworkReply *download(const QUrl &url);
+    void cancelDownload(const QModelIndex &index);
     void cancelDownloads();
 
     void loadUserFeedList();

--- a/src/libs/ui/progressitemdelegate.h
+++ b/src/libs/ui/progressitemdelegate.h
@@ -44,8 +44,15 @@ public:
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
                const QModelIndex &index) const override;
 
+    bool editorEvent(QEvent *event, QAbstractItemModel *model,
+                     const QStyleOptionViewItem &option, const QModelIndex &index) override;
+
+signals:
+    void cancelButtonClicked(const QModelIndex& index);
+
 private:
     static const int progressBarWidth = 150;
+    static const int cancelButtonWidth = 50;
 };
 
 } // namespace WidgetUi


### PR DESCRIPTION
**Preview**

![cancelbuttonspecific](https://user-images.githubusercontent.com/7759435/47961688-ca7edb80-e035-11e8-8315-c4ca7bf81b29.png)

The `Cancel` button cancels the current download by emitting a `cancelButtonClicked` signal. This signal is emitted by overriding `QStyledItemDelegate::editorEvent` and checking if the `QMouseEvent` coordinates fall inside the cancel button bounds