### PR TITLE
Closes #1033: focus search bar text selects all even if focused

### DIFF
--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -159,13 +159,14 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
 
     // Setup application wide shortcuts.
     // Focus search bar.
-    QShortcut *shortcut = new QShortcut(QStringLiteral("Ctrl+K"), this);
-    connect(shortcut, &QShortcut::activated,
-            ui->lineEdit, static_cast<void (SearchEdit::*)()>(&SearchEdit::setFocus));
-
-    shortcut = new QShortcut(QStringLiteral("Ctrl+L"), this);
-    connect(shortcut, &QShortcut::activated,
-            ui->lineEdit, static_cast<void (SearchEdit::*)()>(&SearchEdit::setFocus));
+    QShortcut *shortcut;
+    QStringList searchBarFocusShortcuts;
+    searchBarFocusShortcuts << "Ctrl+K" << "Ctrl+L";
+    for (auto it = searchBarFocusShortcuts.begin(); it != searchBarFocusShortcuts.end(); ++it) {
+        shortcut = new QShortcut(*it, this);
+        connect(shortcut, &QShortcut::activated,
+                ui->lineEdit, static_cast<void (SearchEdit::*)()>(&SearchEdit::setFocus));
+    }
 
     // Duplicate current tab.
     shortcut = new QShortcut(QStringLiteral("Ctrl+Alt+T"), this);

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -165,7 +165,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
     for (auto it = searchBarFocusShortcuts.begin(); it != searchBarFocusShortcuts.end(); ++it) {
         shortcut = new QShortcut(*it, this);
         connect(shortcut, &QShortcut::activated,
-                ui->lineEdit, static_cast<void (SearchEdit::*)()>(&SearchEdit::setFocus));
+                ui->lineEdit, static_cast<void (SearchEdit::*)()>(&SearchEdit::setFocusByShortcut));
     }
 
     // Duplicate current tab.

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -162,7 +162,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
     QShortcut *shortcut;
     QStringList searchBarFocusShortcuts;
     searchBarFocusShortcuts << "Ctrl+K" << "Ctrl+L";
-    for (auto it = searchBarFocusShortcuts.begin(); it != searchBarFocusShortcuts.end(); ++it) {
+    for (auto it = searchBarFocusShortcuts.cbegin(); it != searchBarFocusShortcuts.cend(); ++it) {
         shortcut = new QShortcut(*it, this);
         connect(shortcut, &QShortcut::activated,
                 ui->lineEdit, static_cast<void (SearchEdit::*)()>(&SearchEdit::setFocusByShortcut));

--- a/src/libs/ui/widgets/searchedit.cpp
+++ b/src/libs/ui/widgets/searchedit.cpp
@@ -90,6 +90,14 @@ bool SearchEdit::event(QEvent *event)
     return true;
 }
 
+void SearchEdit::setFocusByShortcut() {
+    // When want the keyboard shortcut that focuses the search bar to always have the same
+    // behavior, even if the search bar is already focused. focusInEvent won't be called if it's
+    // already focused so we work around that by clearing focus before setting focus.
+    clearFocus();
+    setFocus();
+}
+
 void SearchEdit::focusInEvent(QFocusEvent *event)
 {
     QLineEdit::focusInEvent(event);

--- a/src/libs/ui/widgets/searchedit.h
+++ b/src/libs/ui/widgets/searchedit.h
@@ -44,6 +44,7 @@ public:
     void clearQuery();
     void selectQuery();
     void setCompletions(const QStringList &completions);
+    void setFocusByShortcut();
 
 protected:
     bool event(QEvent *event) override;


### PR DESCRIPTION
#1033.

I'm not very familiar with C++ so I apologize for any basic mistakes. :grimacing: 