### PR TITLE
Trim feed URL before trying to resolve it

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -144,6 +144,7 @@ void DocsetsDialog::addDashFeed()
 
     QString feedUrl = QInputDialog::getText(this, QStringLiteral("Zeal"), tr("Feed URL:"),
                                             QLineEdit::Normal, clipboardText);
+    feedUrl = feedUrl.trimmed();
     if (feedUrl.isEmpty())
         return;
 


### PR DESCRIPTION
Sometimes, when copying a feed URL, I accidentally include a leading
whitespace. Zeal then denies the URL since it does not start with a
valid protocol indicator.

This PR trims the feed URL before using it. This might improve the UX
for some users.