### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,16 +9,38 @@
 *.dll
 *.dylib
 
-# Qt Creator
+# Qt-es
+object_script.*.Release
+object_script.*.Debug
+*_plugin_import.cpp
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+moc_*.h
+qrc_*.cpp
+ui_*.h
+*.qmlc
+*.jsc
+Makefile*
+*build-*
+
+# Qt unit tests
+target_wrapper.*
+
+# QtCreator
 *.autosave
 
-# Qt Ctreator QML
+# QtCreator Qml
 *.qmlproject.user
 *.qmlproject.user.*
 
-# CMake
-CMakeLists.txt.user
-build/
+# QtCreator CMake
+CMakeLists.txt.user*
 
 # VS Code
 /.vscode


### PR DESCRIPTION
Hi, I checked out the code and opened it with QtCreator; I started a build and the IDE generated a directory called `build-Desktop-Debug/` which was not being ignored by Git. I took the chance to update the `.gitignore` file using the `Qt` template from [gitignore.io](https://www.gitignore.io), which fixed the issue along with adding more rules that should prevent any unwanted file from being shown as untracked in the future.

In order to check if any _wanted_ file was being left out, I ran `git check-ignore *`, which gave the following output:
```zsh
➜ git check-ignore * 
build-Desktop-Debug
CMakeLists.txt.user
```