### PR TITLE
Replace Q_OS_OSX with Q_OS_MACOS

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -91,7 +91,7 @@ DocsetsDialog::DocsetsDialog(Core::Application *app, QWidget *parent) :
     qt_ntfs_permission_lookup--;
 #endif
 
-#ifdef Q_OS_OSX
+#ifdef Q_OS_MACOS
     ui->availableDocsetList->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->installedDocsetList->setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -432,7 +432,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
         m_tabBar->setCurrentIndex((m_tabBar->currentIndex() - 1 + m_tabBar->count()) % m_tabBar->count());
     });
 
-#ifdef Q_OS_OSX
+#ifdef Q_OS_MACOS
     ui->treeView->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->tocListView->setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif

--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut.cpp
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut.cpp
@@ -55,32 +55,32 @@
 
 #include <QAbstractEventDispatcher>
 
-#ifndef Q_OS_OSX
+#ifndef Q_OS_MACOS
 int QxtGlobalShortcutPrivate::ref = 0;
-#endif // Q_OS_OSX
+#endif // Q_OS_MACOS
 
 QHash<QPair<quint32, quint32>, QxtGlobalShortcut *> QxtGlobalShortcutPrivate::shortcuts;
 
 QxtGlobalShortcutPrivate::QxtGlobalShortcutPrivate(QxtGlobalShortcut *qq) :
     q_ptr(qq)
 {
-#ifndef Q_OS_OSX
+#ifndef Q_OS_MACOS
     if (ref == 0)
         QAbstractEventDispatcher::instance()->installNativeEventFilter(this);
     ++ref;
-#endif // Q_OS_OSX
+#endif // Q_OS_MACOS
 }
 
 QxtGlobalShortcutPrivate::~QxtGlobalShortcutPrivate()
 {
-#ifndef Q_OS_OSX
+#ifndef Q_OS_MACOS
     --ref;
     if (ref == 0) {
         QAbstractEventDispatcher *ed = QAbstractEventDispatcher::instance();
         if (ed != 0)
             ed->removeNativeEventFilter(this);
     }
-#endif // Q_OS_OSX
+#endif // Q_OS_MACOS
 }
 
 bool QxtGlobalShortcutPrivate::setShortcut(const QKeySequence &shortcut)

--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_p.h
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_p.h
@@ -72,9 +72,9 @@ public:
     Qt::Key key = Qt::Key(0);
     Qt::KeyboardModifiers mods = Qt::NoModifier;
 
-#ifndef Q_OS_OSX
+#ifndef Q_OS_MACOS
     static int ref;
-#endif // Q_OS_OSX
+#endif // Q_OS_MACOS
 
     bool setShortcut(const QKeySequence &shortcut);
     bool unsetShortcut();


### PR DESCRIPTION
[According to the Qt docs](https://doc.qt.io/qt-5/qtglobal.html#Q_OS_OSX), the `Q_OS_OSX` macro is deprecated and
`Q_OS_MACOS` should be used instead.

I ran a mixture of `find` and `sed` over the `src/` folder to replace all occurrences.

Not a big deal after all, but I thought it was a fair change.