### PR TITLE
Avoid creation of unnecessary objects

### DIFF
--- a/src/libs/registry/docset.h
+++ b/src/libs/registry/docset.h
@@ -43,7 +43,7 @@ struct SearchResult;
 class Docset
 {
 public:
-    explicit Docset(const QString &path);
+    explicit Docset(QString path);
     ~Docset();
 
     bool isValid() const;

--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -150,7 +150,8 @@ void DocsetRegistry::unloadDocset(const QString &name)
 
 void DocsetRegistry::unloadAllDocsets()
 {
-    for (const QString &name : m_docsets.keys()) {
+    const auto keys = m_docsets.keys();
+    for (const QString &name : keys) {
         unloadDocset(name);
     }
 }

--- a/src/libs/registry/listmodel.cpp
+++ b/src/libs/registry/listmodel.cpp
@@ -195,7 +195,8 @@ void ListModel::addDocset(const QString &name)
     DocsetItem *docsetItem = new DocsetItem();
     docsetItem->docset = m_docsetRegistry->docset(name);
 
-    for (const QString &symbolType : docsetItem->docset->symbolCounts().keys()) {
+    const auto keys = docsetItem->docset->symbolCounts().keys();
+    for (const QString &symbolType : keys) {
         GroupItem *groupItem = new GroupItem();
         groupItem->docsetItem = docsetItem;
         groupItem->symbolType = symbolType;

--- a/src/libs/registry/searchquery.cpp
+++ b/src/libs/registry/searchquery.cpp
@@ -23,6 +23,8 @@
 
 #include "searchquery.h"
 
+#include <utility>
+
 using namespace Zeal::Registry;
 
 namespace {
@@ -34,8 +36,8 @@ SearchQuery::SearchQuery()
 {
 }
 
-SearchQuery::SearchQuery(const QString &query, const QStringList &keywords) :
-    m_query(query)
+SearchQuery::SearchQuery(QString query, const QStringList &keywords) :
+    m_query(std::move(query))
 {
     setKeywords(keywords);
 }

--- a/src/libs/registry/searchquery.h
+++ b/src/libs/registry/searchquery.h
@@ -36,7 +36,7 @@ class SearchQuery
 {
 public:
     explicit SearchQuery();
-    explicit SearchQuery(const QString &query, const QStringList &keywords = QStringList());
+    explicit SearchQuery(QString query, const QStringList &keywords = QStringList());
 
     /// Creates a search query from a string. Single separator will be
     /// used to contstruct docset filter, but separator repeated twice


### PR DESCRIPTION
Qt containers return a deep copy when used in a loop with a call to a member function such as [`QMap::keys()`](https://doc.qt.io/qt-5/qmap.html#keys) or [`QMap::values(const Key& key)`](https://doc.qt.io/qt-5/qmap.html#values-1).
Using iterators or assigning the return value to a const object avoids the copy, thanks to the implicit sharing feature of Qt.
See the code examples [here](https://doc.qt.io/qt-5/qtglobal.html#qAsConst).

Further, when arguments in a constructor are to be passed to a member's constructor, taking the argument by value and then moving it can be beneficial when the argument is an rvalue as it will avoid the call to a copy constructor, thanks to move semantics.
See [here](https://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html).