### PR TITLE
Set default zoom of webview based on DPI.

### DIFF
--- a/src/libs/browser/webview.cpp
+++ b/src/libs/browser/webview.cpp
@@ -39,7 +39,7 @@
 using namespace Zeal::Browser;
 
 WebView::WebView(QWidget *parent)
-    : QWebView(parent), m_zoomLevel(0)
+    : QWebView(parent)
 {
     page()->setNetworkAccessManager(Core::Application::instance()->networkManager());
     // Applies any DPI based scaling.
@@ -63,7 +63,7 @@ void WebView::setZoomLevel(int level)
     m_zoomLevel = level;
 
     // Scale the webview relative to the DPI of the screen.
-    qreal dpiZoomFactor = logicalDpiY() / 96.0;
+    const float dpiZoomFactor = logicalDpiY() / 96.0;
 
     setZoomFactor(availableZoomLevels().at(level) / 100.0 * dpiZoomFactor);
     emit zoomLevelChanged();

--- a/src/libs/browser/webview.cpp
+++ b/src/libs/browser/webview.cpp
@@ -39,9 +39,11 @@
 using namespace Zeal::Browser;
 
 WebView::WebView(QWidget *parent)
-    : QWebView(parent)
+    : QWebView(parent), m_zoomLevel(0)
 {
     page()->setNetworkAccessManager(Core::Application::instance()->networkManager());
+    // Applies any DPI based scaling.
+    setZoomLevel(defaultZoomLevel());
 }
 
 int WebView::zoomLevel() const
@@ -60,7 +62,10 @@ void WebView::setZoomLevel(int level)
 
     m_zoomLevel = level;
 
-    setZoomFactor(availableZoomLevels().at(level) / 100.0);
+    // Scale the webview relative to the DPI of the screen.
+    qreal dpiZoomFactor = logicalDpiY() / 96.0;
+
+    setZoomFactor(availableZoomLevels().at(level) / 100.0 * dpiZoomFactor);
     emit zoomLevelChanged();
 }
 
@@ -72,7 +77,7 @@ const QVector<int> &WebView::availableZoomLevels()
     return zoomLevels;
 }
 
-const int &WebView::defaultZoomLevel()
+int WebView::defaultZoomLevel()
 {
     static const int level = availableZoomLevels().indexOf(100);
     return level;

--- a/src/libs/browser/webview.h
+++ b/src/libs/browser/webview.h
@@ -66,7 +66,7 @@ private:
 
     QMenu *m_contextMenu = nullptr;
     QUrl m_clickedLink;
-    int m_zoomLevel;
+    int m_zoomLevel = 0;
 };
 
 } // namespace Browser

--- a/src/libs/browser/webview.h
+++ b/src/libs/browser/webview.h
@@ -42,7 +42,7 @@ public:
     void setZoomLevel(int level);
 
     static const QVector<int> &availableZoomLevels();
-    static const int &defaultZoomLevel();
+    static int defaultZoomLevel();
 
 public slots:
     void zoomIn();
@@ -66,7 +66,7 @@ private:
 
     QMenu *m_contextMenu = nullptr;
     QUrl m_clickedLink;
-    int m_zoomLevel = defaultZoomLevel();
+    int m_zoomLevel;
 };
 
 } // namespace Browser


### PR DESCRIPTION
Control zoom factor directly rather than using hardcoded zoom levels.

In order to ensure that the webview starts out scaled appropriately to the
current font DPI, we set default zoom level based on current DPI, e.g.:

  96 DPI - 100% zoom
  120 DPI - 125% zoom

Since this will allow zoom levels beyond the predefined set, I also change the
logic for zooming to simply add or remove 10% to the current scaling.

Note that if we want to still maintain the predefined zoom levels, I can rewrite this to multiply the predefined zoom levels by the zoom level derived from the current DPI.