### PR TITLE
libs: enforce static linking of internal libs

### DIFF
--- a/src/libs/browser/CMakeLists.txt
+++ b/src/libs/browser/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Browser
+add_library(Browser STATIC
     webcontrol.cpp
     searchtoolbar.cpp
     webbridge.cpp

--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Core
+add_library(Core STATIC
     application.cpp
     applicationsingleton.cpp
     extractor.cpp

--- a/src/libs/registry/CMakeLists.txt
+++ b/src/libs/registry/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Registry
+add_library(Registry STATIC
     cancellationtoken.h
     docset.cpp
     docsetmetadata.cpp

--- a/src/libs/ui/CMakeLists.txt
+++ b/src/libs/ui/CMakeLists.txt
@@ -8,7 +8,7 @@ set(Ui_FORMS
     settingsdialog.ui
 )
 
-add_library(Ui
+add_library(Ui STATIC
     aboutdialog.cpp
     docsetlistitemdelegate.cpp
     docsetsdialog.cpp

--- a/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
+++ b/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
@@ -19,7 +19,7 @@ elseif(WIN32)
     )
 endif()
 
-add_library(QxtGlobalShortcut ${QxtGlobalShortcut_SOURCES})
+add_library(QxtGlobalShortcut STATIC ${QxtGlobalShortcut_SOURCES})
 
 find_package(Qt5Gui REQUIRED)
 target_link_libraries(QxtGlobalShortcut Qt5::Gui)

--- a/src/libs/ui/widgets/CMakeLists.txt
+++ b/src/libs/ui/widgets/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Widgets
+add_library(Widgets STATIC
     searchedit.cpp
     shortcutedit.cpp
     toolbarframe.cpp

--- a/src/libs/util/CMakeLists.txt
+++ b/src/libs/util/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Nothing to moc here, so avoid empty build units.
 set(CMAKE_AUTOMOC OFF)
 
-add_library(Util
+add_library(Util STATIC
     caseinsensitivemap.h
     plist.cpp
     sqlitedatabase.cpp


### PR DESCRIPTION
Since the application binary is the only file installed and the libs are
not used by anyone else, make sure they are always static. Otherwise
cmake can make them shared and those shared libs will be missing after
install.

Signed-off-by: Henning Schild <henning@hennsch.de>