### PR TITLE
Add dark UI theme and custom theme support

### DIFF
--- a/src/app/resources/css/darkorange.stylesheet
+++ b/src/app/resources/css/darkorange.stylesheet
@@ -1,0 +1,441 @@
+QToolTip
+{
+     border: 1px solid black;
+     background-color: #ffa02f;
+     padding: 1px;
+     border-radius: 3px;
+     opacity: 100;
+}
+
+QWidget
+{
+    color: #b1b1b1;
+    background-color: #323232;
+}
+
+QWidget:item:hover
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
+    color: #000000;
+}
+
+QWidget:item:selected
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+}
+
+QMenuBar::item
+{
+    background: transparent;
+}
+
+QMenuBar::item:selected
+{
+    background: transparent;
+    border: 1px solid #ffaa00;
+}
+
+QMenuBar::item:pressed
+{
+    background: #444;
+    border: 1px solid #000;
+    background-color: QLinearGradient(
+        x1:0, y1:0,
+        x2:0, y2:1,
+        stop:1 #212121,
+        stop:0.4 #343434/*,
+        stop:0.2 #343434,
+        stop:0.1 #ffaa00*/
+    );
+    margin-bottom:-1px;
+    padding-bottom:1px;
+}
+
+QMenu
+{
+    border: 1px solid #000;
+}
+
+QMenu::item
+{
+    padding: 2px 20px 2px 20px;
+}
+
+QMenu::item:selected
+{
+    color: #000000;
+}
+
+QWidget:disabled
+{
+    color: #404040;
+    background-color: #323232;
+}
+
+QAbstractItemView
+{
+    color: #b1b1b1;
+    background-color: #3A3A3A;
+/*     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #4d4d4d, stop: 0.1 #646464, stop: 1 #5d5d5d); */
+}
+
+QWidget:focus
+{
+    /*border: 2px solid QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);*/
+}
+
+QLineEdit
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #4d4d4d, stop: 0 #646464, stop: 1 #5d5d5d);
+    padding: 1px;
+    border-style: solid;
+    border: 1px solid #1e1e1e;
+/*     border-radius: 5; */
+}
+
+QPushButton
+{
+    color: #b1b1b1;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #565656, stop: 0.1 #525252, stop: 0.5 #4e4e4e, stop: 0.9 #4a4a4a, stop: 1 #464646);
+    border-width: 1px;
+    border-color: #1e1e1e;
+    border-style: solid;
+    border-radius: 6;
+    padding: 3px;
+    font-size: 12px;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+
+QPushButton:pressed
+{
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #2d2d2d, stop: 0.1 #2b2b2b, stop: 0.5 #292929, stop: 0.9 #282828, stop: 1 #252525);
+}
+
+QComboBox
+{
+    selection-background-color: #ffaa00;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #565656, stop: 0.1 #525252, stop: 0.5 #4e4e4e, stop: 0.9 #4a4a4a, stop: 1 #464646);
+    border-style: solid;
+    border: 1px solid #1e1e1e;
+    border-radius: 5;
+}
+
+QComboBox:hover,QPushButton:hover
+{
+    border: 2px solid QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+}
+
+
+QComboBox:on
+{
+    padding-top: 3px;
+    padding-left: 4px;
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #2d2d2d, stop: 0.1 #2b2b2b, stop: 0.5 #292929, stop: 0.9 #282828, stop: 1 #252525);
+    selection-background-color: #ffaa00;
+}
+
+QComboBox QAbstractItemView
+{
+    border: 2px solid darkgray;
+    selection-background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+}
+
+QComboBox::drop-down
+{
+     subcontrol-origin: padding;
+     subcontrol-position: top right;
+     width: 15px;
+
+     border-left-width: 0px;
+     border-left-color: darkgray;
+     border-left-style: solid; /* just a single line */
+     border-top-right-radius: 3px; /* same radius as the QComboBox */
+     border-bottom-right-radius: 3px;
+ }
+
+
+QGroupBox:focus
+{
+border: 2px solid QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+}
+
+QTextEdit:focus
+{
+    border: 2px solid QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+}
+
+QScrollBar:horizontal {
+     border: 1px solid #222222;
+     background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0.0 #121212, stop: 0.2 #282828, stop: 1 #484848);
+     margin: 0px 16px 0 16px;
+}
+
+QScrollBar::handle:horizontal
+{
+      background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 0.5 #d7801a, stop: 1 #ffa02f);
+      min-height: 20px;
+      border-radius: 2px;
+}
+
+QScrollBar::add-line:horizontal {
+      border: 1px solid #1b1b19;
+      border-radius: 2px;
+      background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 1 #d7801a);
+      width: 14px;
+      subcontrol-position: right;
+      subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal {
+      border: 1px solid #1b1b19;
+      border-radius: 2px;
+      background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #ffa02f, stop: 1 #d7801a);
+      width: 14px;
+     subcontrol-position: left;
+     subcontrol-origin: margin;
+}
+
+QScrollBar::right-arrow:horizontal, QScrollBar::left-arrow:horizontal
+{
+      border: 1px solid black;
+      width: 1px;
+      height: 1px;
+      background: white;
+}
+
+QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal
+{
+      background: none;
+}
+
+QScrollBar:vertical
+{
+      background: QLinearGradient( x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.0 #121212, stop: 0.2 #282828, stop: 1 #484848);
+      margin: 16px 0 16px 0;
+      border: 1px solid #222222;
+}
+
+QScrollBar::handle:vertical
+{
+      background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 0.5 #d7801a, stop: 1 #ffa02f);
+      min-height: 20px;
+      border-radius: 2px;
+}
+
+QScrollBar::add-line:vertical
+{
+      border: 1px solid #1b1b19;
+      border-radius: 2px;
+      background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #d7801a);
+      height: 14px;
+      subcontrol-position: bottom;
+      subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:vertical
+{
+      border: 1px solid #1b1b19;
+      border-radius: 2px;
+      background: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #d7801a, stop: 1 #ffa02f);
+      height: 14px;
+      subcontrol-position: top;
+      subcontrol-origin: margin;
+}
+
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical
+{
+      border: 1px solid black;
+      width: 1px;
+      height: 1px;
+      background: white;
+}
+
+
+QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
+{
+      background: none;
+}
+
+QTextEdit
+{
+    background-color: #242424;
+}
+
+QPlainTextEdit
+{
+    background-color: #242424;
+}
+
+QHeaderView::section
+{
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #616161, stop: 0.5 #505050, stop: 0.6 #434343, stop:1 #656565);
+    color: white;
+    padding-left: 4px;
+    border: 1px solid #6c6c6c;
+}
+
+QCheckBox:disabled
+{
+color: #414141;
+}
+
+QDockWidget::title
+{
+    text-align: center;
+    spacing: 3px; /* spacing between items in the tool bar */
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #323232, stop: 0.5 #242424, stop:1 #323232);
+}
+
+QDockWidget::close-button, QDockWidget::float-button
+{
+    text-align: center;
+    spacing: 1px; /* spacing between items in the tool bar */
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #323232, stop: 0.5 #242424, stop:1 #323232);
+}
+
+QDockWidget::close-button:hover, QDockWidget::float-button:hover
+{
+    background: #242424;
+}
+
+QDockWidget::close-button:pressed, QDockWidget::float-button:pressed
+{
+    padding: 1px -1px -1px 1px;
+}
+
+QMainWindow::separator
+{
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #161616, stop: 0.5 #151515, stop: 0.6 #212121, stop:1 #343434);
+    color: white;
+    padding-left: 4px;
+    border: 1px solid #4c4c4c;
+    spacing: 3px; /* spacing between items in the tool bar */
+}
+
+QMainWindow::separator:hover
+{
+
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #d7801a, stop:0.5 #b56c17 stop:1 #ffa02f);
+    color: white;
+    padding-left: 4px;
+    border: 1px solid #6c6c6c;
+    spacing: 3px; /* spacing between items in the tool bar */
+}
+
+QMenu::separator
+{
+    height: 2px;
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #161616, stop: 0.5 #151515, stop: 0.6 #212121, stop:1 #343434);
+    color: white;
+    padding-left: 4px;
+    margin-left: 10px;
+    margin-right: 5px;
+}
+
+QProgressBar
+{
+    border: 2px solid grey;
+    border-radius: 5px;
+    text-align: center;
+}
+
+QProgressBar::chunk
+{
+    background-color: #d7801a;
+    width: 2.15px;
+    margin: 0.5px;
+}
+
+QTabBar::tab {
+    color: #b1b1b1;
+    border: 1px solid #444;
+    border-bottom-style: none;
+    background-color: #323232;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 3px;
+    padding-bottom: 2px;
+    margin-right: -1px;
+}
+
+QTabWidget::pane {
+    border: 1px solid #444;
+    top: 1px;
+}
+
+QTabBar::tab:last
+{
+    margin-right: 0; /* the last selected tab has nothing to overlap with on the right */
+    border-top-right-radius: 3px;
+}
+
+QTabBar::tab:first:!selected
+{
+ margin-left: 0px; /* the last selected tab has nothing to overlap with on the right */
+
+
+    border-top-left-radius: 3px;
+}
+
+QTabBar::tab:!selected
+{
+    color: #b1b1b1;
+    border-bottom-style: solid;
+    margin-top: 3px;
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:1 #212121, stop:.4 #343434);
+}
+
+QTabBar::tab:selected
+{
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    margin-bottom: 0px;
+}
+
+QTabBar::tab:!selected:hover
+{
+    /*border-top: 2px solid #ffaa00;
+    padding-bottom: 3px;*/
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:1 #212121, stop:0.4 #343434, stop:0.2 #343434, stop:0.1 #ffaa00);
+}
+
+QRadioButton::indicator:checked, QRadioButton::indicator:unchecked{
+    color: #b1b1b1;
+    background-color: #323232;
+    border: 1px solid #b1b1b1;
+    border-radius: 6px;
+}
+
+QRadioButton::indicator:checked
+{
+    background-color: qradialgradient(
+        cx: 0.5, cy: 0.5,
+        fx: 0.5, fy: 0.5,
+        radius: 1.0,
+        stop: 0.25 #ffaa00,
+        stop: 0.3 #323232
+    );
+}
+
+QRadioButton::indicator
+{
+    border-radius: 6px;
+}
+
+QRadioButton::indicator:hover, QCheckBox::indicator:hover
+{
+    border: 1px solid #ffaa00;
+}
+
+QCheckBox::indicator:disabled, QRadioButton::indicator:disabled
+{
+    border: 1px solid #444;
+}
+
+QCheckBox::indicator:checked
+{
+    background-color: #aa8800;
+}

--- a/src/app/resources/zeal.qrc
+++ b/src/app/resources/zeal.qrc
@@ -244,5 +244,6 @@
         <file>icons/logo/128x128.png</file>
         <file>icons/logo/icon.png</file>
         <file>icons/logo/icon@2x.png</file>
+        <file>css/darkorange.stylesheet</file>
     </qresource>
 </RCC>

--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -51,6 +51,7 @@ Settings::Settings(QObject *parent) :
     QObject(parent)
 {
     qRegisterMetaTypeStreamOperators<ExternalLinkPolicy>("ExternalLinkPolicy");
+    qRegisterMetaTypeStreamOperators<UiStyle>("UiStyle");
 
     // Enable local storage due to https://github.com/zealdocs/zeal/issues/872.
     QWebSettings *webSettings = QWebSettings::globalSettings();
@@ -135,6 +136,9 @@ void Settings::load()
     darkModeEnabled = settings->value(QStringLiteral("dark_mode"), false).toBool();
     highlightOnNavigateEnabled = settings->value(QStringLiteral("highlight_on_navigate"), true).toBool();
     customCssFile = settings->value(QStringLiteral("custom_css_file")).toString();
+    uiStyle = settings->value(QStringLiteral("ui_style"),
+                                         QVariant::fromValue(UiStyle::SystemDefault)).value<UiStyle>();
+    customUiCssFile = settings->value(QStringLiteral("custom_ui_css_file")).toString();
     externalLinkPolicy = settings->value(QStringLiteral("external_link_policy"),
                                          QVariant::fromValue(ExternalLinkPolicy::Ask)).value<ExternalLinkPolicy>();
     isSmoothScrollingEnabled = settings->value(QStringLiteral("smooth_scrolling"), false).toBool();
@@ -224,6 +228,8 @@ void Settings::save()
     settings->setValue(QStringLiteral("dark_mode"), darkModeEnabled);
     settings->setValue(QStringLiteral("highlight_on_navigate"), highlightOnNavigateEnabled);
     settings->setValue(QStringLiteral("custom_css_file"), customCssFile);
+    settings->setValue(QStringLiteral("ui_style"), QVariant::fromValue(uiStyle));
+    settings->setValue(QStringLiteral("custom_ui_css_file"), customUiCssFile);
     settings->setValue(QStringLiteral("external_link_policy"), QVariant::fromValue(externalLinkPolicy));
     settings->setValue(QStringLiteral("smooth_scrolling"), isSmoothScrollingEnabled);
     settings->endGroup();
@@ -345,5 +351,19 @@ QDataStream &operator>>(QDataStream &in, Settings::ExternalLinkPolicy &policy)
     std::underlying_type<Settings::ExternalLinkPolicy>::type value;
     in >> value;
     policy = static_cast<Settings::ExternalLinkPolicy>(value);
+    return in;
+}
+
+QDataStream &operator<<(QDataStream &out, Settings::UiStyle uiStyle)
+{
+    out << static_cast<std::underlying_type<Settings::UiStyle>::type>(uiStyle);
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, Settings::UiStyle &uiStyle)
+{
+    std::underlying_type<Settings::UiStyle>::type value;
+    in >> value;
+    uiStyle = static_cast<Settings::UiStyle>(value);
     return in;
 }

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -83,6 +83,15 @@ public:
     QString customCssFile;
     bool isSmoothScrollingEnabled;
 
+    enum class UiStyle {
+        SystemDefault,
+        Dark,
+        CustomCssFile
+    };
+    Q_ENUM(UiStyle)
+    UiStyle uiStyle = UiStyle::SystemDefault;
+    QString customUiCssFile;
+
     // Network
     enum ProxyType : unsigned int {
         None = 0,

--- a/src/libs/ui/searchitemdelegate.cpp
+++ b/src/libs/ui/searchitemdelegate.cpp
@@ -123,13 +123,18 @@ void SearchItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     const QString elidedText = fm.elidedText(opt.text, opt.textElideMode, textRect.width());
 
     if (!m_highlight.isEmpty()) {
+        QColor highlightColor = QColor::fromRgb(255, 255, 100);
+        if(painter->pen().color().toHsv().value() > 127)
+            highlightColor = QColor::fromRgb(100, 100, 0);;
+
+        if(opt.state & (QStyle::State_Selected | QStyle::State_HasFocus))
+            highlightColor.setAlpha(20);
+        else
+            highlightColor.setAlpha(120);
+
         painter->save();
         painter->setRenderHint(QPainter::Antialiasing);
         painter->setPen(QColor::fromRgb(255, 253, 0));
-
-        const QColor highlightColor
-                = (opt.state & (QStyle::State_Selected | QStyle::State_HasFocus))
-                ? QColor::fromRgb(255, 255, 100, 20) : QColor::fromRgb(255, 255, 100, 120);
 
         for (int i = 0;;) {
             const int matchIndex = opt.text.indexOf(m_highlight, i, Qt::CaseInsensitive);

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -141,6 +141,17 @@ void SettingsDialog::chooseCustomCssFile()
     ui->customCssFileEdit->setText(QDir::toNativeSeparators(file));
 }
 
+void SettingsDialog::chooseCustomUiCssFile()
+{
+    const QString file = QFileDialog::getOpenFileName(this, tr("Choose UI CSS File"),
+                                                      ui->customCssFileEdit->text(),
+                                                      tr("CSS Files (*.css);;All Files (*.*)"));
+    if (file.isEmpty())
+        return;
+
+    ui->customUiCssFileEdit->setText(QDir::toNativeSeparators(file));
+}
+
 void SettingsDialog::chooseDocsetStoragePath()
 {
     QString path = QFileDialog::getExistingDirectory(this, tr("Open Directory"),
@@ -200,6 +211,19 @@ void SettingsDialog::loadSettings()
     ui->darkModeCheckBox->setChecked(settings->darkModeEnabled);
     ui->highlightOnNavigateCheckBox->setChecked(settings->highlightOnNavigateEnabled);
     ui->customCssFileEdit->setText(QDir::toNativeSeparators(settings->customCssFile));
+
+    switch (settings->uiStyle) {
+    case Core::Settings::UiStyle::SystemDefault:
+        ui->radioUiStyleSystemDefault->setChecked(true);
+        break;
+    case Core::Settings::UiStyle::Dark:
+        ui->radioUiStyleDark->setChecked(true);
+        break;
+    case Core::Settings::UiStyle::CustomCssFile:
+        ui->radioUiStyleCustomCssFile->setChecked(true);
+        break;
+    }
+    ui->customUiCssFileEdit->setText(QDir::toNativeSeparators(settings->customUiCssFile));
 
     switch (settings->externalLinkPolicy) {
     case Core::Settings::ExternalLinkPolicy::Ask:
@@ -275,6 +299,15 @@ void SettingsDialog::saveSettings()
     settings->darkModeEnabled = ui->darkModeCheckBox->isChecked();
     settings->highlightOnNavigateEnabled = ui->highlightOnNavigateCheckBox->isChecked();
     settings->customCssFile = QDir::fromNativeSeparators(ui->customCssFileEdit->text());
+
+    if (ui->radioUiStyleSystemDefault->isChecked()) {
+        settings->uiStyle = Core::Settings::UiStyle::SystemDefault;
+    } else if (ui->radioUiStyleDark->isChecked()) {
+        settings->uiStyle = Core::Settings::UiStyle::Dark;
+    } else if (ui->radioUiStyleCustomCssFile->isChecked()) {
+        settings->uiStyle = Core::Settings::UiStyle::CustomCssFile;
+    }
+    settings->customUiCssFile = QDir::fromNativeSeparators(ui->customUiCssFileEdit->text());
 
     if (ui->radioExternalLinkAsk->isChecked()) {
         settings->externalLinkPolicy = Core::Settings::ExternalLinkPolicy::Ask;

--- a/src/libs/ui/settingsdialog.h
+++ b/src/libs/ui/settingsdialog.h
@@ -42,6 +42,7 @@ public:
 
 private slots:
     void chooseCustomCssFile();
+    void chooseCustomUiCssFile();
     void chooseDocsetStoragePath();
 
 private:

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -22,6 +22,42 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
+     <widget class="QWidget" name="tabsTab">
+      <attribute name="title">
+       <string>Tabs</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QGroupBox" name="groupBox_6">
+         <property name="title">
+          <string>Behavior</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_12">
+          <item>
+           <widget class="QCheckBox" name="openNewTabAfterActive">
+            <property name="text">
+             <string>Open new tab after active</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
        <string>General</string>
@@ -80,6 +116,54 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_8">
+         <property name="title">
+          <string>UI Style</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_15">
+          <item>
+           <widget class="QRadioButton" name="radioUiStyleSystemDefault">
+            <property name="text">
+             <string>System default</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="radioUiStyleDark">
+            <property name="text">
+             <string>Dark style</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QRadioButton" name="radioUiStyleCustomCssFile">
+              <property name="text">
+               <string>Custom CSS file: </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="customUiCssFileEdit">
+              <property name="clearButtonEnabled" stdset="0">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="customUiCssFileBrowseButton">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="globalHotKeyGroupBox">
          <property name="title">
           <string>Global shortcuts</string>
@@ -100,7 +184,7 @@
             <property name="placeholderText">
              <string>Click to set shortcut</string>
             </property>
-            <property name="clearButtonEnabled">
+            <property name="clearButtonEnabled" stdset="0">
              <bool>true</bool>
             </property>
            </widget>
@@ -131,7 +215,7 @@
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
              <widget class="QLineEdit" name="docsetStorageEdit">
-              <property name="clearButtonEnabled">
+              <property name="clearButtonEnabled" stdset="0">
                <bool>true</bool>
               </property>
              </widget>
@@ -150,42 +234,6 @@
        </item>
        <item>
         <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabsTab">
-      <attribute name="title">
-       <string>Tabs</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <item>
-        <widget class="QGroupBox" name="groupBox_6">
-         <property name="title">
-          <string>Behavior</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_12">
-          <item>
-           <widget class="QCheckBox" name="openNewTabAfterActive">
-            <property name="text">
-             <string>Open new tab after active</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_5">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -408,7 +456,7 @@
        <item>
         <widget class="QGroupBox" name="styleGroupBox">
          <property name="title">
-          <string>Style</string>
+          <string>Doc Style</string>
          </property>
          <layout class="QFormLayout" name="formLayout_5">
           <item row="1" column="0" colspan="2">
@@ -439,7 +487,7 @@
             </item>
             <item>
              <widget class="QLineEdit" name="customCssFileEdit">
-              <property name="clearButtonEnabled">
+              <property name="clearButtonEnabled" stdset="0">
                <bool>true</bool>
               </property>
              </widget>
@@ -776,6 +824,22 @@
    <signal>clicked()</signal>
    <receiver>Zeal::WidgetUi::SettingsDialog</receiver>
    <slot>chooseCustomCssFile()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>526</x>
+     <y>232</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>299</x>
+     <y>249</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>customUiCssFileBrowseButton</sender>
+   <signal>clicked()</signal>
+   <receiver>Zeal::WidgetUi::SettingsDialog</receiver>
+   <slot>chooseCustomUiCssFile()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>526</x>

--- a/src/libs/ui/widgets/searchedit.cpp
+++ b/src/libs/ui/widgets/searchedit.cpp
@@ -42,7 +42,7 @@ SearchEdit::SearchEdit(QWidget *parent) :
 
     m_completionLabel = new QLabel(this);
     m_completionLabel->setObjectName(QStringLiteral("completer"));
-    m_completionLabel->setStyleSheet(QStringLiteral("QLabel#completer { color: gray; }"));
+    m_completionLabel->setStyleSheet(QStringLiteral("QLabel#completer { color: gray; background-color: transparent; }"));
     m_completionLabel->setFont(font());
 
     connect(this, &SearchEdit::textChanged, this, &SearchEdit::showCompletions);


### PR DESCRIPTION
Enable user CSS and dark mode for the UI from the settings dialog. Fix some graphics issue with dark mode described in #466.

For the dark mode is used the dark orange stylesheet from http://discourse.techart.online/t/release-qt-dark-orange-stylesheet/2287 with small modifications.
