### PR TITLE
Fix missing app icon on Wayland

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -218,6 +218,10 @@ int main(int argc, char *argv[])
     qapp->setWindowIcon(QIcon::fromTheme(QStringLiteral("zeal"),
                                          QIcon(QStringLiteral(":/zeal.ico"))));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
+    qapp->setDesktopFileName(QStringLiteral("org.zealdocs.Zeal.desktop"));
+#endif
+
     QDir::setSearchPaths(QStringLiteral("typeIcon"), {QStringLiteral(":/icons/type")});
 
     QScopedPointer<Core::Application> app(new Core::Application());


### PR DESCRIPTION
Wayland uses the .desktop file to find the app icon. Without it being specified the correct icon is not shown. 

Tested on Gnome/Wayland.

References:
* https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon
* https://doc.qt.io/qt-5/qguiapplication.html#desktopFileName-prop