### PR TITLE
fix(ui): correctly position search completer label on HiDPI display

### DIFF
--- a/src/libs/ui/widgets/searchedit.cpp
+++ b/src/libs/ui/widgets/searchedit.cpp
@@ -154,9 +154,10 @@ void SearchEdit::showCompletions(const QString &newValue)
 
     const QString completed = currentCompletion(newValue).mid(newValue.size());
     const QSize labelSize(fontMetrics().width(completed), size().height());
+    const int shiftX = static_cast<int>(window()->devicePixelRatioF() * (frameWidth + 2)) + textWidth;
 
     m_completionLabel->setMinimumSize(labelSize);
-    m_completionLabel->move(frameWidth + 2 + textWidth, 0);
+    m_completionLabel->move(shiftX, 0);
     m_completionLabel->setText(completed);
 }
 


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/529520/64967878-86897380-d8a1-11e9-9332-2c2336ba4f0f.png)

After: 
![image](https://user-images.githubusercontent.com/529520/64967975-b59fe500-d8a1-11e9-80bd-4b10309f757a.png)

Test carried out under KDE, with a scaling factor of 2.

Note that I did not really test how it behaves on a normal DPI screen or multiple screens with different DPI, because of lack of devices.