### PR TITLE
Fix Qt 5.11 deprecation warning for QFontMetrics::width

### DIFF
--- a/src/libs/core/extractor.cpp
+++ b/src/libs/core/extractor.cpp
@@ -56,7 +56,7 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
 
     QDir destinationDir(destination);
     if (!root.isEmpty()) {
-        destinationDir = destinationDir.filePath(root);
+        destinationDir.setPath(destinationDir.filePath(root));
     }
 
     // TODO: Do not strip root directory in archive if it equals to 'root'

--- a/src/libs/ui/searchitemdelegate.cpp
+++ b/src/libs/ui/searchitemdelegate.cpp
@@ -135,11 +135,16 @@ void SearchItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
             const int matchIndex = opt.text.indexOf(m_highlight, i, Qt::CaseInsensitive);
             if (matchIndex == -1 || matchIndex >= elidedText.length() - 1)
                 break;
-
-            QRect highlightRect
-                    = textRect.adjusted(fm.width(elidedText.left(matchIndex)), 2, 0, -2);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+            QRect highlightRect = textRect.adjusted(fm.horizontalAdvance(elidedText.left(matchIndex)), 2, 0, -2);
+#else
+            QRect highlightRect = textRect.adjusted(fm.width(elidedText.left(matchIndex)), 2, 0, -2);
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+            highlightRect.setWidth(fm.horizontalAdvance(elidedText.mid(matchIndex, m_highlight.length())));
+#else
             highlightRect.setWidth(fm.width(elidedText.mid(matchIndex, m_highlight.length())));
-
+#endif
             QPainterPath path;
             path.addRoundedRect(highlightRect, 2, 2);
 
@@ -202,8 +207,11 @@ QSize SearchItemDelegate::sizeHint(const QStyleOptionViewItem &option,
         const int decorationWidth = std::min(opt.decorationSize.width(), actualSize.width());
         size.rwidth() = (decorationWidth + margin) * roles.size() + margin;
     }
-
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    size.rwidth() += opt.fontMetrics.horizontalAdvance(index.data().toString()) + margin * 2;
+#else
     size.rwidth() += opt.fontMetrics.width(index.data().toString()) + margin * 2;
+#endif
     return size;
 }
 

--- a/src/libs/ui/widgets/searchedit.cpp
+++ b/src/libs/ui/widgets/searchedit.cpp
@@ -147,13 +147,21 @@ void SearchEdit::showCompletions(const QString &newValue)
         return;
 
     const int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    const int textWidth = fontMetrics().horizontalAdvance(newValue);
+#else
     const int textWidth = fontMetrics().width(newValue);
+#endif
 
     if (m_prefixCompleter)
         m_prefixCompleter->setCompletionPrefix(text());
 
     const QString completed = currentCompletion(newValue).mid(newValue.size());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    const QSize labelSize(fontMetrics().horizontalAdvance(completed), size().height());
+#else
     const QSize labelSize(fontMetrics().width(completed), size().height());
+#endif
     const int shiftX = static_cast<int>(window()->devicePixelRatioF() * (frameWidth + 2)) + textWidth;
 
     m_completionLabel->setMinimumSize(labelSize);


### PR DESCRIPTION
Building on my Arch Linux box with Qt 5.13.1 installed showed a few warnings saying that the `QFontMetrics::width()` and `QDir::operator=(const QString&)` were deprecated. I replaced them with the new alternatives and wrapped them with a compile-time check, which wasn't needed for `QDir::operator=(const QDir&)`. Now it should compile cleanly.

Since I saw you already made a very similar fix, by skimming through the log, I reused the same commit message of that old commit.