### PR TITLE
Modernize code base with clang-tidy's modernize-*

### DIFF
--- a/src/libs/browser/webview.cpp
+++ b/src/libs/browser/webview.cpp
@@ -227,7 +227,7 @@ void WebView::mouseReleaseEvent(QMouseEvent *event)
                         .arg(clickedLink.toString()));
 
 
-            QCheckBox *checkBox = new QCheckBox("Do &not ask again");
+            auto checkBox = new QCheckBox("Do &not ask again");
             mb->setCheckBox(checkBox);
 
             QPushButton *openInBrowserButton = mb->addButton(tr("Open in &Desktop Browser"),

--- a/src/libs/core/application.cpp
+++ b/src/libs/core/application.cpp
@@ -47,7 +47,7 @@ using namespace Zeal;
 using namespace Zeal::Core;
 
 namespace {
-const char ReleasesApiUrl[] = "https://api.zealdocs.org/v1/releases";
+constexpr char ReleasesApiUrl[] = "https://api.zealdocs.org/v1/releases";
 }
 
 Application *Application::m_instance = nullptr;

--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -35,14 +35,14 @@
 
 namespace {
 // Configuration file groups
-const char GroupContent[] = "content";
-const char GroupDocsets[] = "docsets";
-const char GroupGlobalShortcuts[] = "global_shortcuts";
-const char GroupSearch[] = "search";
-const char GroupTabs[] = "tabs";
-const char GroupInternal[] = "internal";
-const char GroupState[] = "state";
-const char GroupProxy[] = "proxy";
+constexpr char GroupContent[] = "content";
+constexpr char GroupDocsets[] = "docsets";
+constexpr char GroupGlobalShortcuts[] = "global_shortcuts";
+constexpr char GroupSearch[] = "search";
+constexpr char GroupTabs[] = "tabs";
+constexpr char GroupInternal[] = "internal";
+constexpr char GroupState[] = "state";
+constexpr char GroupProxy[] = "proxy";
 }
 
 using namespace Zeal::Core;

--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -46,19 +46,19 @@
 using namespace Zeal::Registry;
 
 namespace {
-const char IndexNamePrefix[] = "__zi_name"; // zi - Zeal index
-const char IndexNameVersion[] = "0001"; // Current index version
+constexpr char IndexNamePrefix[] = "__zi_name"; // zi - Zeal index
+constexpr char IndexNameVersion[] = "0001"; // Current index version
 
 namespace InfoPlist {
-const char CFBundleName[] = "CFBundleName";
+constexpr char CFBundleName[] = "CFBundleName";
 //const char CFBundleIdentifier[] = "CFBundleIdentifier";
-const char DashDocSetFamily[] = "DashDocSetFamily";
-const char DashDocSetKeyword[] = "DashDocSetKeyword";
-const char DashDocSetPluginKeyword[] = "DashDocSetPluginKeyword";
-const char DashIndexFilePath[] = "dashIndexFilePath";
-const char DocSetPlatformFamily[] = "DocSetPlatformFamily";
+constexpr char DashDocSetFamily[] = "DashDocSetFamily";
+constexpr char DashDocSetKeyword[] = "DashDocSetKeyword";
+constexpr char DashDocSetPluginKeyword[] = "DashDocSetPluginKeyword";
+constexpr char DashIndexFilePath[] = "dashIndexFilePath";
+constexpr char DocSetPlatformFamily[] = "DocSetPlatformFamily";
 //const char IsDashDocset[] = "isDashDocset";
-const char IsJavaScriptEnabled[] = "isJavaScriptEnabled";
+constexpr char IsJavaScriptEnabled[] = "isJavaScriptEnabled";
 }
 }
 

--- a/src/libs/sidebar/container.cpp
+++ b/src/libs/sidebar/container.cpp
@@ -55,10 +55,7 @@ Container::Container(QWidget *parent)
     setLayout(layout);
 }
 
-Container::~Container()
-{
-
-}
+Container::~Container() = default;
 
 void Container::addView(View *view)
 {

--- a/src/libs/sidebar/proxyview.cpp
+++ b/src/libs/sidebar/proxyview.cpp
@@ -28,13 +28,15 @@
 
 #include <QVBoxLayout>
 
+#include <utility>
+
 using namespace Zeal;
 using namespace Zeal::Sidebar;
 
-ProxyView::ProxyView(ViewProvider *provider, const QString &id, QWidget *parent)
+ProxyView::ProxyView(ViewProvider *provider, QString id, QWidget *parent)
     : View(parent)
     , m_viewProvider(provider)
-    , m_viewId(id)
+    , m_viewId(std::move(id))
 {
     setLayout(WidgetUi::LayoutHelper::createBorderlessLayout<QVBoxLayout>());
 

--- a/src/libs/sidebar/proxyview.h
+++ b/src/libs/sidebar/proxyview.h
@@ -34,7 +34,7 @@ class ProxyView final : public View
 {
     Q_OBJECT
 public:
-    explicit ProxyView(ViewProvider *provider, const QString &id = QString(), QWidget *parent = nullptr);
+    explicit ProxyView(ViewProvider *provider, QString id = QString(), QWidget *parent = nullptr);
     ~ProxyView() override;
 
 private:

--- a/src/libs/ui/browsertab.cpp
+++ b/src/libs/ui/browsertab.cpp
@@ -46,7 +46,7 @@ using namespace Zeal;
 using namespace Zeal::WidgetUi;
 
 namespace {
-const char WelcomePageUrl[] = "qrc:///browser/welcome.html";
+constexpr char WelcomePageUrl[] = "qrc:///browser/welcome.html";
 } // namespace
 
 BrowserTab::BrowserTab(QWidget *parent)

--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -54,18 +54,18 @@ extern Q_CORE_EXPORT int qt_ntfs_permission_lookup;
 #endif
 
 namespace {
-const char ApiServerUrl[] = "https://api.zealdocs.org/v1";
-const char RedirectServerUrl[] = "https://go.zealdocs.org";
+constexpr char ApiServerUrl[] = "https://api.zealdocs.org/v1";
+constexpr char RedirectServerUrl[] = "https://go.zealdocs.org";
 // TODO: Each source plugin should have its own cache
-const char DocsetListCacheFileName[] = "com.kapeli.json";
+constexpr char DocsetListCacheFileName[] = "com.kapeli.json";
 
 // TODO: Make the timeout period configurable
 constexpr int CacheTimeout = 24 * 60 * 60 * 1000; // 24 hours in microseconds
 
 // QNetworkReply properties
-const char DocsetNameProperty[] = "docsetName";
-const char DownloadTypeProperty[] = "downloadType";
-const char ListItemIndexProperty[] = "listItem";
+constexpr char DocsetNameProperty[] = "docsetName";
+constexpr char DownloadTypeProperty[] = "downloadType";
+constexpr char ListItemIndexProperty[] = "listItem";
 }
 
 DocsetsDialog::DocsetsDialog(Core::Application *app, QWidget *parent)
@@ -729,8 +729,7 @@ void DocsetsDialog::processDocsetList(const QJsonArray &list)
     for (const auto &kv : m_availableDocsets) {
         const auto &metadata = kv.second;
 
-        QListWidgetItem *listItem
-                = new QListWidgetItem(metadata.icon(), metadata.title(), ui->availableDocsetList);
+        auto listItem = new QListWidgetItem(metadata.icon(), metadata.title(), ui->availableDocsetList);
         listItem->setData(Registry::ItemDataRole::DocsetNameRole, metadata.name());
 
         if (m_docsetRegistry->contains(metadata.name())) {

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -59,8 +59,8 @@ using namespace Zeal;
 using namespace Zeal::WidgetUi;
 
 namespace {
-const char DarkModeCssUrl[] = ":/browser/assets/css/darkmode.css";
-const char HighlightOnNavigateCssUrl[] = ":/browser/assets/css/highlight.css";
+constexpr char DarkModeCssUrl[] = ":/browser/assets/css/darkmode.css";
+constexpr char HighlightOnNavigateCssUrl[] = ":/browser/assets/css/highlight.css";
 }
 
 MainWindow::MainWindow(Core::Application *app, QWidget *parent)
@@ -81,7 +81,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent)
 
     // Setup application wide shortcuts.
     // Focus search bar.
-    QShortcut *shortcut = new QShortcut(QStringLiteral("Ctrl+K"), this);
+    auto shortcut = new QShortcut(QStringLiteral("Ctrl+K"), this);
     connect(shortcut, &QShortcut::activated, this, [this]() { currentTab()->searchSidebar()->focusSearchEdit(); });
 
     shortcut = new QShortcut(QStringLiteral("Ctrl+L"), this);

--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_p.h
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_p.h
@@ -79,8 +79,7 @@ public:
     bool setShortcut(const QKeySequence &shortcut);
     bool unsetShortcut();
 
-    virtual bool nativeEventFilter(const QByteArray &eventType, void *message,
-                                   long *result) override;
+    bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) override;
 
     static bool activateShortcut(quint32 nativeKey, quint32 nativeMods);
 

--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
@@ -62,7 +62,7 @@
 #include <xcb/xcb_keysyms.h>
 
 namespace {
-const quint32 maskModifiers[] = {
+constexpr quint32 maskModifiers[] = {
     0, XCB_MOD_MASK_2, XCB_MOD_MASK_LOCK, (XCB_MOD_MASK_2 | XCB_MOD_MASK_LOCK)
 };
 } // namespace

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -38,12 +38,12 @@ using namespace Zeal::WidgetUi;
 
 namespace {
 // QFontDatabase::standardSizes() lacks some sizes, like 13, which QtWK uses by default.
-const int AvailableFontSizes[] = {9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-                                  20, 22, 24, 26, 28, 30, 32, 34, 36,
-                                  40, 44, 48, 56, 64, 72};
-const QWebSettings::FontFamily BasicFontFamilies[] = {QWebSettings::SerifFont,
-                                                      QWebSettings::SansSerifFont,
-                                                      QWebSettings::FixedFont};
+constexpr int AvailableFontSizes[] = {9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+                                      20, 22, 24, 26, 28, 30, 32, 34, 36,
+                                      40, 44, 48, 56, 64, 72};
+constexpr QWebSettings::FontFamily BasicFontFamilies[] = {QWebSettings::SerifFont,
+                                                          QWebSettings::SansSerifFont,
+                                                          QWebSettings::FixedFont};
 }
 
 SettingsDialog::SettingsDialog(QWidget *parent)

--- a/src/libs/ui/widgets/searchedit.cpp
+++ b/src/libs/ui/widgets/searchedit.cpp
@@ -90,7 +90,7 @@ bool SearchEdit::event(QEvent *event)
 {
     switch (event->type()) {
     case QEvent::KeyPress: {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        auto keyEvent = static_cast<QKeyEvent *>(event);
         // Tab key cannot be overriden in keyPressEvent().
         if (keyEvent->key() == Qt::Key_Tab) {
             const QString completed = currentCompletion(text());
@@ -113,7 +113,7 @@ bool SearchEdit::event(QEvent *event)
             QStringLiteral("Ctrl+L")
         };
 
-        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        auto keyEvent = static_cast<QKeyEvent *>(event);
         const int keyCode = keyEvent->key() | static_cast<int>(keyEvent->modifiers());
         if (focusShortcuts.contains(QKeySequence(keyCode).toString())) {
             selectQuery();


### PR DESCRIPTION
I ran the code base through the `modernize-*` checks of clang-tidy.
Enhancements include the use of `auto` in order to avoid repeating the type name when obvious from the context, the use of `constexpr` for array literals and usage of move semantics to avoid unnecessary copies.