### PR TITLE
Improve error message when storage does not exist

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -83,7 +83,9 @@ DocsetsDialog::DocsetsDialog(Core::Application *app, QWidget *parent)
     qt_ntfs_permission_lookup++;
 #endif
 
-    m_isStorageReadOnly = !QFileInfo(m_application->settings()->docsetPath).isWritable();
+    const QFileInfo fi(m_application->settings()->docsetPath);
+
+    m_isStorageReadOnly = !fi.isWritable();
 
 #ifdef Q_OS_WIN32
     qt_ntfs_permission_lookup--;
@@ -95,7 +97,10 @@ DocsetsDialog::DocsetsDialog(Core::Application *app, QWidget *parent)
 #endif
 
     ui->statusLabel->clear(); // Clear text shown in the designer mode.
-    ui->readOnlyLabel->setVisible(m_isStorageReadOnly);
+    ui->storageStatusLabel->setVisible(m_isStorageReadOnly);
+    ui->storageStatusLabel->setText(fi.exists() ?
+                                    QStringLiteral("<b>Docset storage is read only.</b>") :
+                                    QStringLiteral("<b>Docset storage does not exist.</b>"));
 
     connect(m_application, &Core::Application::extractionCompleted,
             this, &DocsetsDialog::extractionCompleted);

--- a/src/libs/ui/docsetsdialog.ui
+++ b/src/libs/ui/docsetsdialog.ui
@@ -218,11 +218,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="readOnlyLabel">
-       <property name="text">
-        <string>&lt;b&gt;Docset storage is read only.&lt;/b&gt;</string>
-       </property>
-      </widget>
+      <widget class="QLabel" name="storageStatusLabel"/>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
When the user modifies the docsets directory from the settings page, the docsets page shows `Docset storage is read-only` when the actual source of the error is that the directory does not exist on the file system. This PR fixes that by making the label show the correct error message based on the actual error.