### PR TITLE
core,ui: Provide ability to set a custom javascript polyfills

### DIFF
--- a/src/libs/browser/webview.h
+++ b/src/libs/browser/webview.h
@@ -58,6 +58,7 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void onJavaScriptWindowObjectCleared();
 
 private:
     QWebHitTestResult hitTestContent(const QPoint &pos) const;

--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -135,6 +135,7 @@ void Settings::load()
     darkModeEnabled = settings->value(QStringLiteral("dark_mode"), false).toBool();
     highlightOnNavigateEnabled = settings->value(QStringLiteral("highlight_on_navigate"), true).toBool();
     customCssFile = settings->value(QStringLiteral("custom_css_file")).toString();
+    customPolyfillsFile = settings->value(QStringLiteral("custom_polyfills_file")).toString();
     externalLinkPolicy = settings->value(QStringLiteral("external_link_policy"),
                                          QVariant::fromValue(ExternalLinkPolicy::Ask)).value<ExternalLinkPolicy>();
     isSmoothScrollingEnabled = settings->value(QStringLiteral("smooth_scrolling"), false).toBool();
@@ -224,6 +225,7 @@ void Settings::save()
     settings->setValue(QStringLiteral("dark_mode"), darkModeEnabled);
     settings->setValue(QStringLiteral("highlight_on_navigate"), highlightOnNavigateEnabled);
     settings->setValue(QStringLiteral("custom_css_file"), customCssFile);
+    settings->setValue(QStringLiteral("custom_polyfills_file"), customPolyfillsFile);
     settings->setValue(QStringLiteral("external_link_policy"), QVariant::fromValue(externalLinkPolicy));
     settings->setValue(QStringLiteral("smooth_scrolling"), isSmoothScrollingEnabled);
     settings->endGroup();

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -81,6 +81,7 @@ public:
     bool darkModeEnabled;
     bool highlightOnNavigateEnabled;
     QString customCssFile;
+    QString customPolyfillsFile;
     bool isSmoothScrollingEnabled;
 
     // Network

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -146,6 +146,17 @@ void SettingsDialog::chooseCustomCssFile()
     ui->customCssFileEdit->setText(QDir::toNativeSeparators(file));
 }
 
+void SettingsDialog::chooseCustomPolyfillsFile()
+{
+    const QString file = QFileDialog::getOpenFileName(this, tr("Choose JS polyfills File"),
+                                                      ui->customPolyfillsFileEdit->text(),
+                                                      tr("JS Files (*.js);;All Files (*.*)"));
+    if (file.isEmpty())
+        return;
+
+    ui->customPolyfillsFileEdit->setText(QDir::toNativeSeparators(file));
+}
+
 void SettingsDialog::chooseDocsetStoragePath()
 {
     QString path = QFileDialog::getExistingDirectory(this, tr("Open Directory"),
@@ -205,6 +216,7 @@ void SettingsDialog::loadSettings()
     ui->darkModeCheckBox->setChecked(settings->darkModeEnabled);
     ui->highlightOnNavigateCheckBox->setChecked(settings->highlightOnNavigateEnabled);
     ui->customCssFileEdit->setText(QDir::toNativeSeparators(settings->customCssFile));
+    ui->customPolyfillsFileEdit->setText(QDir::toNativeSeparators(settings->customPolyfillsFile));
 
     switch (settings->externalLinkPolicy) {
     case Core::Settings::ExternalLinkPolicy::Ask:
@@ -280,6 +292,7 @@ void SettingsDialog::saveSettings()
     settings->darkModeEnabled = ui->darkModeCheckBox->isChecked();
     settings->highlightOnNavigateEnabled = ui->highlightOnNavigateCheckBox->isChecked();
     settings->customCssFile = QDir::fromNativeSeparators(ui->customCssFileEdit->text());
+    settings->customPolyfillsFile = QDir::fromNativeSeparators(ui->customPolyfillsFileEdit->text());
 
     if (ui->radioExternalLinkAsk->isChecked()) {
         settings->externalLinkPolicy = Core::Settings::ExternalLinkPolicy::Ask;

--- a/src/libs/ui/settingsdialog.h
+++ b/src/libs/ui/settingsdialog.h
@@ -42,6 +42,7 @@ public:
 
 private slots:
     void chooseCustomCssFile();
+    void chooseCustomPolyfillsFile();
     void chooseDocsetStoragePath();
 
 private:

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>625</height>
+    <height>729</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -457,6 +457,43 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="javascriptGroupBox">
+         <property name="title">
+          <string>Javascript</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_7">
+          <item row="1" column="0">
+           <widget class="QLabel" name="customPolyfillsFileLabel">
+            <property name="text">
+             <string>Custom polyfills file:</string>
+            </property>
+            <property name="buddy">
+             <cstring>customPolyfillsFileEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLineEdit" name="customPolyfillsFileEdit">
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="customPolyfillsFileBrowseButton">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox_7">
          <property name="title">
           <string>External Link Behavior</string>
@@ -776,6 +813,22 @@
    <signal>clicked()</signal>
    <receiver>Zeal::WidgetUi::SettingsDialog</receiver>
    <slot>chooseCustomCssFile()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>526</x>
+     <y>232</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>299</x>
+     <y>249</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>customPolyfillsFileBrowseButton</sender>
+   <signal>clicked()</signal>
+   <receiver>Zeal::WidgetUi::SettingsDialog</receiver>
+   <slot>chooseCustomPolyfillsFile()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>526</x>


### PR DESCRIPTION
You can use [iterators-polyfill](https://www.npmjs.com/package/iterators-polyfill) for MDN docsets (or you can get NodeList.prototype.@@iterator-polyfill here [Polyfill.io](https://polyfill.io/v3/url-builder/))