### PR TITLE
Fix broken twitter links in 404.html, welcome.html

### DIFF
--- a/src/app/resources/browser/404.html
+++ b/src/app/resources/browser/404.html
@@ -44,7 +44,7 @@
             <a class="icon" onclick="zAppBridge.openShortUrl('gitter')">
               <i class="fab fa-gitter"></i>
             </a>
-            <a class="icon" onclick="zAppBridge.openShortUrl('twiter')">
+            <a class="icon" onclick="zAppBridge.openShortUrl('twitter')">
               <i class="fab fa-twitter"></i>
             </a>
           </p>

--- a/src/app/resources/browser/welcome.html
+++ b/src/app/resources/browser/welcome.html
@@ -55,7 +55,7 @@
             <a class="icon" onclick="zAppBridge.openShortUrl('gitter')">
               <i class="fab fa-gitter"></i>
             </a>
-            <a class="icon" onclick="zAppBridge.openShortUrl('twiter')">
+            <a class="icon" onclick="zAppBridge.openShortUrl('twitter')">
               <i class="fab fa-twitter"></i>
             </a>
           </p>


### PR DESCRIPTION
Twitter links were broken due to a typo (`twiter` instead of `twitter`).
This pull request fixes the links.

This fixes https://github.com/zealdocs/zeal/issues/1207