### PR TITLE
Add dark UI theme with QPalette and custom css theme support

### DIFF
--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -51,6 +51,7 @@ Settings::Settings(QObject *parent)
     : QObject(parent)
 {
     qRegisterMetaTypeStreamOperators<ExternalLinkPolicy>("ExternalLinkPolicy");
+    qRegisterMetaTypeStreamOperators<UiStyle>("UiStyle");
 
     // Enable local storage due to https://github.com/zealdocs/zeal/issues/872.
     QWebSettings *webSettings = QWebSettings::globalSettings();
@@ -135,6 +136,9 @@ void Settings::load()
     darkModeEnabled = settings->value(QStringLiteral("dark_mode"), false).toBool();
     highlightOnNavigateEnabled = settings->value(QStringLiteral("highlight_on_navigate"), true).toBool();
     customCssFile = settings->value(QStringLiteral("custom_css_file")).toString();
+    uiStyle = settings->value(QStringLiteral("ui_style"),
+                                         QVariant::fromValue(UiStyle::SystemDefault)).value<UiStyle>();
+    customUiCssFile = settings->value(QStringLiteral("custom_ui_css_file")).toString();
     externalLinkPolicy = settings->value(QStringLiteral("external_link_policy"),
                                          QVariant::fromValue(ExternalLinkPolicy::Ask)).value<ExternalLinkPolicy>();
     isSmoothScrollingEnabled = settings->value(QStringLiteral("smooth_scrolling"), false).toBool();
@@ -224,6 +228,8 @@ void Settings::save()
     settings->setValue(QStringLiteral("dark_mode"), darkModeEnabled);
     settings->setValue(QStringLiteral("highlight_on_navigate"), highlightOnNavigateEnabled);
     settings->setValue(QStringLiteral("custom_css_file"), customCssFile);
+    settings->setValue(QStringLiteral("ui_style"), QVariant::fromValue(uiStyle));
+    settings->setValue(QStringLiteral("custom_ui_css_file"), customUiCssFile);
     settings->setValue(QStringLiteral("external_link_policy"), QVariant::fromValue(externalLinkPolicy));
     settings->setValue(QStringLiteral("smooth_scrolling"), isSmoothScrollingEnabled);
     settings->endGroup();
@@ -344,5 +350,19 @@ QDataStream &operator>>(QDataStream &in, Settings::ExternalLinkPolicy &policy)
     std::underlying_type<Settings::ExternalLinkPolicy>::type value;
     in >> value;
     policy = static_cast<Settings::ExternalLinkPolicy>(value);
+    return in;
+}
+
+QDataStream &operator<<(QDataStream &out, Settings::UiStyle uiStyle)
+{
+    out << static_cast<std::underlying_type<Settings::UiStyle>::type>(uiStyle);
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, Settings::UiStyle &uiStyle)
+{
+    std::underlying_type<Settings::UiStyle>::type value;
+    in >> value;
+    uiStyle = static_cast<Settings::UiStyle>(value);
     return in;
 }

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -83,6 +83,15 @@ public:
     QString customCssFile;
     bool isSmoothScrollingEnabled;
 
+    enum class UiStyle {
+        SystemDefault,
+        Dark,
+        CustomCssFile
+    };
+    Q_ENUM(UiStyle)
+    UiStyle uiStyle = UiStyle::SystemDefault;
+    QString customUiCssFile;
+
     // Network
     enum ProxyType : unsigned int {
         None = 0,

--- a/src/libs/ui/searchitemdelegate.cpp
+++ b/src/libs/ui/searchitemdelegate.cpp
@@ -123,13 +123,18 @@ void SearchItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     const QString elidedText = fm.elidedText(opt.text, opt.textElideMode, textRect.width());
 
     if (!m_highlight.isEmpty()) {
+        QColor highlightColor = QColor::fromRgb(255, 255, 100);
+        if(painter->pen().color().toHsv().value() > 127)
+            highlightColor = QColor::fromRgb(100, 100, 0);;
+
+        if(opt.state & (QStyle::State_Selected | QStyle::State_HasFocus))
+            highlightColor.setAlpha(20);
+        else
+            highlightColor.setAlpha(120);
+
         painter->save();
         painter->setRenderHint(QPainter::Antialiasing);
         painter->setPen(QColor::fromRgb(255, 253, 0));
-
-        const QColor highlightColor
-                = (opt.state & (QStyle::State_Selected | QStyle::State_HasFocus))
-                ? QColor::fromRgb(255, 255, 100, 20) : QColor::fromRgb(255, 255, 100, 120);
 
         for (int i = 0;;) {
             const int matchIndex = opt.text.indexOf(m_highlight, i, Qt::CaseInsensitive);

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -146,6 +146,17 @@ void SettingsDialog::chooseCustomCssFile()
     ui->customCssFileEdit->setText(QDir::toNativeSeparators(file));
 }
 
+void SettingsDialog::chooseCustomUiCssFile()
+{
+    const QString file = QFileDialog::getOpenFileName(this, tr("Choose UI CSS File"),
+                                                      ui->customCssFileEdit->text(),
+                                                      tr("CSS Files (*.css);;All Files (*.*)"));
+    if (file.isEmpty())
+        return;
+
+    ui->customUiCssFileEdit->setText(QDir::toNativeSeparators(file));
+}
+
 void SettingsDialog::chooseDocsetStoragePath()
 {
     QString path = QFileDialog::getExistingDirectory(this, tr("Open Directory"),
@@ -205,6 +216,19 @@ void SettingsDialog::loadSettings()
     ui->darkModeCheckBox->setChecked(settings->darkModeEnabled);
     ui->highlightOnNavigateCheckBox->setChecked(settings->highlightOnNavigateEnabled);
     ui->customCssFileEdit->setText(QDir::toNativeSeparators(settings->customCssFile));
+
+    switch (settings->uiStyle) {
+    case Core::Settings::UiStyle::SystemDefault:
+        ui->radioUiStyleSystemDefault->setChecked(true);
+        break;
+    case Core::Settings::UiStyle::Dark:
+        ui->radioUiStyleDark->setChecked(true);
+        break;
+    case Core::Settings::UiStyle::CustomCssFile:
+        ui->radioUiStyleCustomCssFile->setChecked(true);
+        break;
+    }
+    ui->customUiCssFileEdit->setText(QDir::toNativeSeparators(settings->customUiCssFile));
 
     switch (settings->externalLinkPolicy) {
     case Core::Settings::ExternalLinkPolicy::Ask:
@@ -280,6 +304,15 @@ void SettingsDialog::saveSettings()
     settings->darkModeEnabled = ui->darkModeCheckBox->isChecked();
     settings->highlightOnNavigateEnabled = ui->highlightOnNavigateCheckBox->isChecked();
     settings->customCssFile = QDir::fromNativeSeparators(ui->customCssFileEdit->text());
+
+    if (ui->radioUiStyleSystemDefault->isChecked()) {
+        settings->uiStyle = Core::Settings::UiStyle::SystemDefault;
+    } else if (ui->radioUiStyleDark->isChecked()) {
+        settings->uiStyle = Core::Settings::UiStyle::Dark;
+    } else if (ui->radioUiStyleCustomCssFile->isChecked()) {
+        settings->uiStyle = Core::Settings::UiStyle::CustomCssFile;
+    }
+    settings->customUiCssFile = QDir::fromNativeSeparators(ui->customUiCssFileEdit->text());
 
     if (ui->radioExternalLinkAsk->isChecked()) {
         settings->externalLinkPolicy = Core::Settings::ExternalLinkPolicy::Ask;

--- a/src/libs/ui/settingsdialog.h
+++ b/src/libs/ui/settingsdialog.h
@@ -42,6 +42,7 @@ public:
 
 private slots:
     void chooseCustomCssFile();
+    void chooseCustomUiCssFile();
     void chooseDocsetStoragePath();
 
 private:

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -80,6 +80,54 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_8">
+         <property name="title">
+          <string>UI Style</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_15">
+          <item>
+           <widget class="QRadioButton" name="radioUiStyleSystemDefault">
+            <property name="text">
+             <string>System default</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="radioUiStyleDark">
+            <property name="text">
+             <string>Dark style</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QRadioButton" name="radioUiStyleCustomCssFile">
+              <property name="text">
+               <string>Custom CSS file: </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="customUiCssFileEdit">
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="customUiCssFileBrowseButton">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="globalHotKeyGroupBox">
          <property name="title">
           <string>Global shortcuts</string>
@@ -408,7 +456,7 @@
        <item>
         <widget class="QGroupBox" name="styleGroupBox">
          <property name="title">
-          <string>Style</string>
+          <string>Doc Style</string>
          </property>
          <layout class="QFormLayout" name="formLayout_5">
           <item row="1" column="0" colspan="2">
@@ -776,6 +824,22 @@
    <signal>clicked()</signal>
    <receiver>Zeal::WidgetUi::SettingsDialog</receiver>
    <slot>chooseCustomCssFile()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>526</x>
+     <y>232</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>299</x>
+     <y>249</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>customUiCssFileBrowseButton</sender>
+   <signal>clicked()</signal>
+   <receiver>Zeal::WidgetUi::SettingsDialog</receiver>
+   <slot>chooseCustomUiCssFile()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>526</x>

--- a/src/libs/ui/widgets/searchedit.cpp
+++ b/src/libs/ui/widgets/searchedit.cpp
@@ -41,7 +41,7 @@ SearchEdit::SearchEdit(QWidget *parent)
 
     m_completionLabel = new QLabel(this);
     m_completionLabel->setObjectName(QStringLiteral("completer"));
-    m_completionLabel->setStyleSheet(QStringLiteral("QLabel#completer { color: gray; }"));
+    m_completionLabel->setStyleSheet(QStringLiteral("QLabel#completer { color: gray; background-color: transparent; }"));
     m_completionLabel->setFont(font());
 
     connect(this, &SearchEdit::textChanged, this, &SearchEdit::showCompletions);


### PR DESCRIPTION
Add dark Ui theme based on QPalette and provide a simple way to use custom css file. For the dark UI the Qt style is changed to fusion to avoid problems with other styles (WindowsVista style does allow to change button color).

Only tested on Linux (I currently have no Windows system with development environment, sorry).

The chosen colors are only a suggestion, they can be replaced.