### PR TITLE
feat(ui): add page zoom controls

### DIFF
--- a/src/libs/browser/webcontrol.cpp
+++ b/src/libs/browser/webcontrol.cpp
@@ -54,6 +54,11 @@ int WebControl::zoomLevel() const
     return m_webView->zoomLevel();
 }
 
+int WebControl::zoomLevelPercentage() const
+{
+    return m_webView->availableZoomLevels().at(zoomLevel());
+}
+
 void WebControl::setZoomLevel(int level)
 {
     m_webView->setZoomLevel(level);

--- a/src/libs/browser/webcontrol.cpp
+++ b/src/libs/browser/webcontrol.cpp
@@ -38,6 +38,7 @@ WebControl::WebControl(QWidget *parent)
     });
     connect(m_webView, &QWebEngineView::titleChanged, this, &WebControl::titleChanged);
     connect(m_webView, &QWebEngineView::urlChanged, this, &WebControl::urlChanged);
+    connect(m_webView, &WebView::zoomLevelChanged, this, &WebControl::zoomLevelChanged);
 
     layout->addWidget(m_webView);
 
@@ -54,14 +55,14 @@ int WebControl::zoomLevel() const
     return m_webView->zoomLevel();
 }
 
-int WebControl::zoomLevelPercentage() const
-{
-    return m_webView->availableZoomLevels().at(zoomLevel());
-}
-
 void WebControl::setZoomLevel(int level)
 {
     m_webView->setZoomLevel(level);
+}
+
+int WebControl::zoomLevelPercentage() const
+{
+    return WebView::availableZoomLevels().value(m_webView->zoomLevel(), 100);
 }
 
 void WebControl::zoomIn()

--- a/src/libs/browser/webcontrol.h
+++ b/src/libs/browser/webcontrol.h
@@ -35,6 +35,7 @@ public:
     QByteArray saveHistory() const;
 
     int zoomLevel() const;
+    int zoomLevelPercentage() const;
     void setZoomLevel(int level);
     void setJavaScriptEnabled(bool enabled);
 

--- a/src/libs/browser/webcontrol.h
+++ b/src/libs/browser/webcontrol.h
@@ -35,15 +35,17 @@ public:
     QByteArray saveHistory() const;
 
     int zoomLevel() const;
-    int zoomLevelPercentage() const;
     void setZoomLevel(int level);
-    void setJavaScriptEnabled(bool enabled);
 
+    int zoomLevelPercentage() const;
+
+    void setJavaScriptEnabled(bool enabled);
     void setWebBridgeObject(const QString &name, QObject *object);
 
 signals:
     void titleChanged(const QString &title);
     void urlChanged(const QUrl &url);
+    void zoomLevelChanged();
 
 public slots:
     void activateSearchBar();

--- a/src/libs/ui/browsertab.cpp
+++ b/src/libs/ui/browsertab.cpp
@@ -6,6 +6,7 @@
 #include "searchsidebar.h"
 #include "widgets/layouthelper.h"
 #include "widgets/toolbarframe.h"
+#include "widgets/browserzoomwidget.h"
 
 #include <browser/webcontrol.h>
 #include <core/application.h>
@@ -17,10 +18,12 @@
 #include <QKeyEvent>
 #include <QLabel>
 #include <QMenu>
+#include <QPushButton>
 #include <QStyle>
 #include <QToolButton>
 #include <QVBoxLayout>
 #include <QWebEngineHistory>
+#include <QWidgetAction>
 
 namespace Zeal::WidgetUi {
 
@@ -120,22 +123,38 @@ BrowserTab::BrowserTab(QWidget *parent)
     m_browserActionButton->setArrowType(Qt::NoArrow);
     m_browserActionButton->setPopupMode(QToolButton::InstantPopup);
 
-    auto browserActionsMenu = new QMenu(m_browserActionButton);
+    auto zoomActionWidget = new BrowserZoomWidget();
 
-    m_browserZoomInAction = browserActionsMenu->addAction(tr("Zoom In"), [this] () {
+    connect(zoomActionWidget->zoomInButton(), &QPushButton::clicked, [this, zoomActionWidget]() {
         m_webControl->zoomIn();
+        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
+        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
     });
 
-    m_browserZoomOutAction = browserActionsMenu->addAction(tr("Zoom Out"), [this] () {
+    connect(zoomActionWidget->zoomOutButton(), &QPushButton::clicked, [this, zoomActionWidget]() {
         m_webControl->zoomOut();
+        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
+        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
     });
 
-    m_browserResetZoomAction = browserActionsMenu->addAction(tr("Reset Zoom"), [this] () {
+    connect(zoomActionWidget->resetZoomButton(), &QPushButton::clicked, [this, zoomActionWidget]() {
         m_webControl->resetZoom();
+        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
+        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
+    });
+
+    auto zoomWidgetAction = new QWidgetAction(this);
+    zoomWidgetAction->setDefaultWidget(zoomActionWidget);
+
+    auto browserActionsMenu = new QMenu(m_browserActionButton);
+    browserActionsMenu->addAction(zoomWidgetAction);
+
+    connect(browserActionsMenu, &QMenu::aboutToShow, [this, zoomActionWidget] () {
+        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
+        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
     });
 
     m_browserActionButton->setMenu(browserActionsMenu);
-    browserActionsMenu->installEventFilter(this);
 
     auto *toolBarLayout = new QHBoxLayout();
     toolBarLayout->setContentsMargins(4, 0, 4, 0);
@@ -234,29 +253,4 @@ QIcon BrowserTab::docsetIcon(const QUrl &url) const
 {
     Registry::Docset *docset = Core::Application::instance()->docsetRegistry()->docsetForUrl(url);
     return docset ? docset->icon() : QIcon(QStringLiteral(":/icons/logo/icon.png"));
-}
-
-bool BrowserTab::eventFilter(QObject *watched, QEvent *event)
-{
-    if (watched == m_browserActionButton->menu()) {
-        QAction *triggeredAction = nullptr;
-
-        if (event->type() == QEvent::MouseButtonRelease) {
-            triggeredAction = m_browserActionButton->menu()->activeAction();
-        } else if (event->type() == QEvent::KeyPress) {
-            const auto *keyEvent = static_cast<QKeyEvent *>(event);
-
-            if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return) {
-                triggeredAction = m_browserActionButton->menu()->activeAction();
-            }
-        }
-
-        if (triggeredAction
-            && (triggeredAction == m_browserZoomInAction || triggeredAction == m_browserZoomOutAction)) {
-            triggeredAction->trigger();
-            return true;
-        }
-    }
-
-    return false;
 }

--- a/src/libs/ui/browsertab.cpp
+++ b/src/libs/ui/browsertab.cpp
@@ -4,9 +4,9 @@
 #include "browsertab.h"
 
 #include "searchsidebar.h"
+#include "widgets/browserzoomwidget.h"
 #include "widgets/layouthelper.h"
 #include "widgets/toolbarframe.h"
-#include "widgets/browserzoomwidget.h"
 
 #include <browser/webcontrol.h>
 #include <core/application.h>
@@ -15,10 +15,8 @@
 #include <registry/searchquery.h>
 
 #include <QApplication>
-#include <QKeyEvent>
 #include <QLabel>
 #include <QMenu>
-#include <QPushButton>
 #include <QStyle>
 #include <QToolButton>
 #include <QVBoxLayout>
@@ -117,44 +115,31 @@ BrowserTab::BrowserTab(QWidget *parent)
 
         label->setText(title);
     });
-    m_browserActionButton = new QToolButton();
-    m_browserActionButton->setAutoRaise(true);
-    m_browserActionButton->setText(QStringLiteral("⋮"));
-    m_browserActionButton->setArrowType(Qt::NoArrow);
-    m_browserActionButton->setPopupMode(QToolButton::InstantPopup);
 
-    auto zoomActionWidget = new BrowserZoomWidget();
+    // Per-tab actions menu (zoom controls, etc.).
+    auto *zoomWidget = new BrowserZoomWidget();
+    zoomWidget->setZoomPercentage(m_webControl->zoomLevelPercentage());
 
-    connect(zoomActionWidget->zoomInButton(), &QPushButton::clicked, [this, zoomActionWidget]() {
-        m_webControl->zoomIn();
-        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
-        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
+    connect(zoomWidget, &BrowserZoomWidget::zoomInRequested, m_webControl, &Browser::WebControl::zoomIn);
+    connect(zoomWidget, &BrowserZoomWidget::zoomOutRequested, m_webControl, &Browser::WebControl::zoomOut);
+    connect(zoomWidget, &BrowserZoomWidget::resetZoomRequested, m_webControl, &Browser::WebControl::resetZoom);
+    connect(m_webControl, &Browser::WebControl::zoomLevelChanged, zoomWidget, [this, zoomWidget]() {
+        zoomWidget->setZoomPercentage(m_webControl->zoomLevelPercentage());
     });
 
-    connect(zoomActionWidget->zoomOutButton(), &QPushButton::clicked, [this, zoomActionWidget]() {
-        m_webControl->zoomOut();
-        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
-        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
-    });
+    auto *zoomAction = new QWidgetAction(this);
+    zoomAction->setDefaultWidget(zoomWidget);
 
-    connect(zoomActionWidget->resetZoomButton(), &QPushButton::clicked, [this, zoomActionWidget]() {
-        m_webControl->resetZoom();
-        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
-        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
-    });
+    auto *actionsMenu = new QMenu(this);
+    actionsMenu->addAction(zoomAction);
 
-    auto zoomWidgetAction = new QWidgetAction(this);
-    zoomWidgetAction->setDefaultWidget(zoomActionWidget);
-
-    auto browserActionsMenu = new QMenu(m_browserActionButton);
-    browserActionsMenu->addAction(zoomWidgetAction);
-
-    connect(browserActionsMenu, &QMenu::aboutToShow, [this, zoomActionWidget] () {
-        const auto zoomLevel = QString("%1%").arg(m_webControl->zoomLevelPercentage());
-        zoomActionWidget->zoomLevelLabel()->setText(zoomLevel);
-    });
-
-    m_browserActionButton->setMenu(browserActionsMenu);
+    auto *actionsButton = new QToolButton();
+    actionsButton->setAutoRaise(true);
+    actionsButton->setMenu(actionsMenu);
+    actionsButton->setPopupMode(QToolButton::InstantPopup);
+    actionsButton->setStyleSheet(QStringLiteral("QToolButton::menu-indicator { image: none; }"));
+    actionsButton->setText(QStringLiteral("⋮"));
+    actionsButton->setToolTip(tr("More actions"));
 
     auto *toolBarLayout = new QHBoxLayout();
     toolBarLayout->setContentsMargins(4, 0, 4, 0);
@@ -163,7 +148,7 @@ BrowserTab::BrowserTab(QWidget *parent)
     toolBarLayout->addWidget(m_backButton);
     toolBarLayout->addWidget(m_forwardButton);
     toolBarLayout->addWidget(label, 1);
-    toolBarLayout->addWidget(m_browserActionButton);
+    toolBarLayout->addWidget(actionsButton);
 
     auto *toolBarFrame = new ToolBarFrame();
     toolBarFrame->setLayout(toolBarLayout);
@@ -254,3 +239,5 @@ QIcon BrowserTab::docsetIcon(const QUrl &url) const
     Registry::Docset *docset = Core::Application::instance()->docsetRegistry()->docsetForUrl(url);
     return docset ? docset->icon() : QIcon(QStringLiteral(":/icons/logo/icon.png"));
 }
+
+} // namespace Zeal::WidgetUi

--- a/src/libs/ui/browsertab.cpp
+++ b/src/libs/ui/browsertab.cpp
@@ -14,6 +14,7 @@
 #include <registry/searchquery.h>
 
 #include <QApplication>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QMenu>
 #include <QStyle>
@@ -113,6 +114,28 @@ BrowserTab::BrowserTab(QWidget *parent)
 
         label->setText(title);
     });
+    m_browserActionButton = new QToolButton();
+    m_browserActionButton->setAutoRaise(true);
+    m_browserActionButton->setText(QStringLiteral("⋮"));
+    m_browserActionButton->setArrowType(Qt::NoArrow);
+    m_browserActionButton->setPopupMode(QToolButton::InstantPopup);
+
+    auto browserActionsMenu = new QMenu(m_browserActionButton);
+
+    m_browserZoomInAction = browserActionsMenu->addAction(tr("Zoom In"), [this] () {
+        m_webControl->zoomIn();
+    });
+
+    m_browserZoomOutAction = browserActionsMenu->addAction(tr("Zoom Out"), [this] () {
+        m_webControl->zoomOut();
+    });
+
+    m_browserResetZoomAction = browserActionsMenu->addAction(tr("Reset Zoom"), [this] () {
+        m_webControl->resetZoom();
+    });
+
+    m_browserActionButton->setMenu(browserActionsMenu);
+    browserActionsMenu->installEventFilter(this);
 
     auto *toolBarLayout = new QHBoxLayout();
     toolBarLayout->setContentsMargins(4, 0, 4, 0);
@@ -121,6 +144,7 @@ BrowserTab::BrowserTab(QWidget *parent)
     toolBarLayout->addWidget(m_backButton);
     toolBarLayout->addWidget(m_forwardButton);
     toolBarLayout->addWidget(label, 1);
+    toolBarLayout->addWidget(m_browserActionButton);
 
     auto *toolBarFrame = new ToolBarFrame();
     toolBarFrame->setLayout(toolBarLayout);
@@ -212,4 +236,27 @@ QIcon BrowserTab::docsetIcon(const QUrl &url) const
     return docset ? docset->icon() : QIcon(QStringLiteral(":/icons/logo/icon.png"));
 }
 
-} // namespace Zeal::WidgetUi
+bool BrowserTab::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == m_browserActionButton->menu()) {
+        QAction *triggeredAction = nullptr;
+
+        if (event->type() == QEvent::MouseButtonRelease) {
+            triggeredAction = m_browserActionButton->menu()->activeAction();
+        } else if (event->type() == QEvent::KeyPress) {
+            const auto *keyEvent = static_cast<QKeyEvent *>(event);
+
+            if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return) {
+                triggeredAction = m_browserActionButton->menu()->activeAction();
+            }
+        }
+
+        if (triggeredAction
+            && (triggeredAction == m_browserZoomInAction || triggeredAction == m_browserZoomOutAction)) {
+            triggeredAction->trigger();
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/libs/ui/browsertab.h
+++ b/src/libs/ui/browsertab.h
@@ -51,12 +51,8 @@ private:
     // Widgets.
     SearchSidebar *m_searchSidebar = nullptr;
     Browser::WebControl *m_webControl = nullptr;
-    QAction *m_browserZoomInAction = nullptr;
-    QAction *m_browserZoomOutAction = nullptr;
-    QAction *m_browserResetZoomAction = nullptr;
     QToolButton *m_backButton = nullptr;
     QToolButton *m_forwardButton = nullptr;
-    QToolButton *m_browserActionButton = nullptr;
 
     // State.
     QUrl m_baseUrl;

--- a/src/libs/ui/browsertab.h
+++ b/src/libs/ui/browsertab.h
@@ -47,7 +47,6 @@ signals:
 
 private:
     QIcon docsetIcon(const QUrl &url) const;
-    bool eventFilter(QObject *watched, QEvent *event) override;
 
     // Widgets.
     SearchSidebar *m_searchSidebar = nullptr;

--- a/src/libs/ui/browsertab.h
+++ b/src/libs/ui/browsertab.h
@@ -47,12 +47,17 @@ signals:
 
 private:
     QIcon docsetIcon(const QUrl &url) const;
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
     // Widgets.
     SearchSidebar *m_searchSidebar = nullptr;
     Browser::WebControl *m_webControl = nullptr;
+    QAction *m_browserZoomInAction = nullptr;
+    QAction *m_browserZoomOutAction = nullptr;
+    QAction *m_browserResetZoomAction = nullptr;
     QToolButton *m_backButton = nullptr;
     QToolButton *m_forwardButton = nullptr;
+    QToolButton *m_browserActionButton = nullptr;
 
     // State.
     QUrl m_baseUrl;

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -356,11 +356,11 @@ void MainWindow::setupMainMenu()
         }
     });
 
-    // Menu bar is global on MacOS, so it should always be visible.
-#ifndef Q_OS_MACOS
     // View Menu.
     menu = m_menuBar->addMenu(tr("&View"));
 
+    // Menu bar is global on MacOS, so it should always be visible.
+#ifndef Q_OS_MACOS
     // -> Toolbars Submenu.
     auto *subMenu = menu->addMenu(tr("&Toolbars"));
 
@@ -389,7 +389,44 @@ void MainWindow::setupMainMenu()
             m_menuBar->setActiveAction(m_menuBar->actions().first());
         }
     });
+
+    menu->addSeparator();
 #endif
+
+    // -> Zoom Submenu.
+    auto *zoomMenu = menu->addMenu(tr("&Zoom"));
+
+    // -> -> Zoom In Action.
+    action = zoomMenu->addAction(QIcon::fromTheme(QStringLiteral("zoom-in")), tr("Zoom &In"));
+    addAction(action);
+    action->setShortcuts({QKeySequence::ZoomIn, QKeySequence(QStringLiteral("Ctrl+="))});
+    connect(action, &QAction::triggered, this, [this]() {
+        if (auto *tab = currentTab()) {
+            tab->webControl()->zoomIn();
+        }
+    });
+
+    // -> -> Zoom Out Action.
+    action = zoomMenu->addAction(QIcon::fromTheme(QStringLiteral("zoom-out")), tr("Zoom &Out"));
+    addAction(action);
+    action->setShortcut(QKeySequence::ZoomOut);
+    connect(action, &QAction::triggered, this, [this]() {
+        if (auto *tab = currentTab()) {
+            tab->webControl()->zoomOut();
+        }
+    });
+
+    zoomMenu->addSeparator();
+
+    // -> -> Actual Size Action.
+    action = zoomMenu->addAction(QIcon::fromTheme(QStringLiteral("zoom-original")), tr("&Actual Size"));
+    addAction(action);
+    action->setShortcut(QKeySequence(QStringLiteral("Ctrl+0")));
+    connect(action, &QAction::triggered, this, [this]() {
+        if (auto *tab = currentTab()) {
+            tab->webControl()->resetZoom();
+        }
+    });
 
     // Tools Menu.
     menu = m_menuBar->addMenu(tr("&Tools"));
@@ -479,30 +516,6 @@ void MainWindow::setupShortcuts()
     connect(shortcut, &QShortcut::activated, this, [this]() {
         if (auto *tab = currentTab()) {
             tab->webControl()->forward();
-        }
-    });
-    shortcut = new QShortcut(QKeySequence::ZoomIn, this);
-    connect(shortcut, &QShortcut::activated, this, [this]() {
-        if (auto *tab = currentTab()) {
-            tab->webControl()->zoomIn();
-        }
-    });
-    shortcut = new QShortcut(QStringLiteral("Ctrl+="), this);
-    connect(shortcut, &QShortcut::activated, this, [this]() {
-        if (auto *tab = currentTab()) {
-            tab->webControl()->zoomIn();
-        }
-    });
-    shortcut = new QShortcut(QKeySequence::ZoomOut, this);
-    connect(shortcut, &QShortcut::activated, this, [this]() {
-        if (auto *tab = currentTab()) {
-            tab->webControl()->zoomOut();
-        }
-    });
-    shortcut = new QShortcut(QStringLiteral("Ctrl+0"), this);
-    connect(shortcut, &QShortcut::activated, this, [this]() {
-        if (auto *tab = currentTab()) {
-            tab->webControl()->resetZoom();
         }
     });
 

--- a/src/libs/ui/widgets/CMakeLists.txt
+++ b/src/libs/ui/widgets/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(Widgets STATIC
     searchedit.cpp
     shortcutedit.cpp
     toolbarframe.cpp
+    browserzoomwidget.cpp
 )
 
 find_package(Qt6 COMPONENTS Widgets REQUIRED)

--- a/src/libs/ui/widgets/CMakeLists.txt
+++ b/src/libs/ui/widgets/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_library(Widgets STATIC
+    browserzoomwidget.cpp
     layouthelper.cpp
     searchedit.cpp
     shortcutedit.cpp
     toolbarframe.cpp
-    browserzoomwidget.cpp
 )
 
 find_package(Qt6 COMPONENTS Widgets REQUIRED)

--- a/src/libs/ui/widgets/browserzoomwidget.cpp
+++ b/src/libs/ui/widgets/browserzoomwidget.cpp
@@ -1,0 +1,75 @@
+#include "browserzoomwidget.h"
+#include <QColor>
+#include <QPalette>
+#include <QPushButton>
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QString>
+
+BrowserZoomWidget::BrowserZoomWidget(QWidget *parent)
+: QWidget(parent)
+{
+    const auto highlightedBackgroundColor = palette().highlight().color().name();
+    const auto highlightedTextColor = palette().highlightedText().color().name();
+    const auto styleSheet
+        = QString("QPushButton:hover { background-color: %1; color: %2; border: none; }").arg(highlightedBackgroundColor)
+                                                                                          .arg(highlightedTextColor);
+    setStyleSheet(styleSheet);
+    setMouseTracking(true);
+    auto zoomLabel = new QLabel(tr("Zoom"));
+    zoomLabel->setMouseTracking(true);
+    zoomLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+
+    constexpr int maxButtonWidth = 32;
+
+    m_zoomOutButton = new QPushButton(QStringLiteral("-"));
+    m_zoomOutButton->setMouseTracking(true);
+    m_zoomOutButton->setMaximumWidth(maxButtonWidth);
+    m_zoomOutButton->setToolTip(tr("Zoom out"));
+
+    m_zoomOutButton->setFlat(true);
+    m_zoomLevelLabel = new QLabel("100%");
+    m_zoomLevelLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    m_zoomLevelLabel->setMouseTracking(true);
+    m_zoomLevelLabel->setToolTip(tr("Current zoom level"));
+
+    m_zoomInButton = new QPushButton(QStringLiteral("+"));
+    m_zoomInButton->setFlat(true);
+    m_zoomInButton->setMouseTracking(true);
+    m_zoomInButton->setMaximumWidth(maxButtonWidth);
+    m_zoomInButton->setToolTip(tr("Zoom in"));
+
+    m_resetZoomButton = new QPushButton(QStringLiteral("↻"));
+    m_resetZoomButton->setFlat(true);
+    m_resetZoomButton->setMouseTracking(true);
+    m_resetZoomButton->setMaximumWidth(maxButtonWidth);
+    m_resetZoomButton->setToolTip(tr("Reset zoom level"));
+
+    auto layout = new QHBoxLayout(this);
+    layout->setSpacing(2);
+    layout->addWidget(zoomLabel);
+    layout->addWidget(m_zoomOutButton);
+    layout->addWidget(m_zoomLevelLabel);
+    layout->addWidget(m_zoomInButton);
+    layout->addWidget(m_resetZoomButton);
+}
+
+QPushButton *BrowserZoomWidget::zoomOutButton()
+{
+    return m_zoomOutButton;
+}
+
+QPushButton *BrowserZoomWidget::zoomInButton()
+{
+    return m_zoomInButton;
+}
+
+QPushButton *BrowserZoomWidget::resetZoomButton()
+{
+    return m_resetZoomButton;
+}
+
+QLabel *BrowserZoomWidget::zoomLevelLabel()
+{
+    return m_zoomLevelLabel;
+}

--- a/src/libs/ui/widgets/browserzoomwidget.cpp
+++ b/src/libs/ui/widgets/browserzoomwidget.cpp
@@ -1,75 +1,63 @@
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "browserzoomwidget.h"
-#include <QColor>
-#include <QPalette>
-#include <QPushButton>
-#include <QLabel>
+
 #include <QHBoxLayout>
-#include <QString>
+#include <QLabel>
+#include <QToolButton>
+
+namespace Zeal::WidgetUi {
+
+namespace {
+constexpr int ButtonWidth = 32;
+} // namespace
 
 BrowserZoomWidget::BrowserZoomWidget(QWidget *parent)
-: QWidget(parent)
+    : QWidget(parent)
 {
-    const auto highlightedBackgroundColor = palette().highlight().color().name();
-    const auto highlightedTextColor = palette().highlightedText().color().name();
-    const auto styleSheet
-        = QString("QPushButton:hover { background-color: %1; color: %2; border: none; }").arg(highlightedBackgroundColor)
-                                                                                          .arg(highlightedTextColor);
-    setStyleSheet(styleSheet);
-    setMouseTracking(true);
-    auto zoomLabel = new QLabel(tr("Zoom"));
-    zoomLabel->setMouseTracking(true);
-    zoomLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    auto *captionLabel = new QLabel(tr("Zoom"));
+    captionLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 
-    constexpr int maxButtonWidth = 32;
+    auto *zoomOutButton = new QToolButton();
+    zoomOutButton->setAutoRaise(true);
+    zoomOutButton->setFixedWidth(ButtonWidth);
+    zoomOutButton->setText(QStringLiteral("−"));
+    zoomOutButton->setToolTip(tr("Zoom out"));
+    connect(zoomOutButton, &QToolButton::clicked, this, &BrowserZoomWidget::zoomOutRequested);
 
-    m_zoomOutButton = new QPushButton(QStringLiteral("-"));
-    m_zoomOutButton->setMouseTracking(true);
-    m_zoomOutButton->setMaximumWidth(maxButtonWidth);
-    m_zoomOutButton->setToolTip(tr("Zoom out"));
+    m_levelLabel = new QLabel(QStringLiteral("100%"));
+    m_levelLabel->setAlignment(Qt::AlignCenter);
+    m_levelLabel->setMinimumWidth(ButtonWidth);
+    m_levelLabel->setToolTip(tr("Current zoom level"));
 
-    m_zoomOutButton->setFlat(true);
-    m_zoomLevelLabel = new QLabel("100%");
-    m_zoomLevelLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    m_zoomLevelLabel->setMouseTracking(true);
-    m_zoomLevelLabel->setToolTip(tr("Current zoom level"));
+    auto *zoomInButton = new QToolButton();
+    zoomInButton->setAutoRaise(true);
+    zoomInButton->setFixedWidth(ButtonWidth);
+    zoomInButton->setText(QStringLiteral("+"));
+    zoomInButton->setToolTip(tr("Zoom in"));
+    connect(zoomInButton, &QToolButton::clicked, this, &BrowserZoomWidget::zoomInRequested);
 
-    m_zoomInButton = new QPushButton(QStringLiteral("+"));
-    m_zoomInButton->setFlat(true);
-    m_zoomInButton->setMouseTracking(true);
-    m_zoomInButton->setMaximumWidth(maxButtonWidth);
-    m_zoomInButton->setToolTip(tr("Zoom in"));
+    auto *resetButton = new QToolButton();
+    resetButton->setAutoRaise(true);
+    resetButton->setFixedWidth(ButtonWidth);
+    resetButton->setText(QStringLiteral("↻"));
+    resetButton->setToolTip(tr("Actual size"));
+    connect(resetButton, &QToolButton::clicked, this, &BrowserZoomWidget::resetZoomRequested);
 
-    m_resetZoomButton = new QPushButton(QStringLiteral("↻"));
-    m_resetZoomButton->setFlat(true);
-    m_resetZoomButton->setMouseTracking(true);
-    m_resetZoomButton->setMaximumWidth(maxButtonWidth);
-    m_resetZoomButton->setToolTip(tr("Reset zoom level"));
-
-    auto layout = new QHBoxLayout(this);
+    auto *layout = new QHBoxLayout(this);
+    layout->setContentsMargins(8, 4, 8, 4);
     layout->setSpacing(2);
-    layout->addWidget(zoomLabel);
-    layout->addWidget(m_zoomOutButton);
-    layout->addWidget(m_zoomLevelLabel);
-    layout->addWidget(m_zoomInButton);
-    layout->addWidget(m_resetZoomButton);
+    layout->addWidget(captionLabel, 1);
+    layout->addWidget(zoomOutButton);
+    layout->addWidget(m_levelLabel);
+    layout->addWidget(zoomInButton);
+    layout->addWidget(resetButton);
 }
 
-QPushButton *BrowserZoomWidget::zoomOutButton()
+void BrowserZoomWidget::setZoomPercentage(int percent)
 {
-    return m_zoomOutButton;
+    m_levelLabel->setText(QStringLiteral("%1%").arg(percent));
 }
 
-QPushButton *BrowserZoomWidget::zoomInButton()
-{
-    return m_zoomInButton;
-}
-
-QPushButton *BrowserZoomWidget::resetZoomButton()
-{
-    return m_resetZoomButton;
-}
-
-QLabel *BrowserZoomWidget::zoomLevelLabel()
-{
-    return m_zoomLevelLabel;
-}
+} // namespace Zeal::WidgetUi

--- a/src/libs/ui/widgets/browserzoomwidget.h
+++ b/src/libs/ui/widgets/browserzoomwidget.h
@@ -1,0 +1,26 @@
+#ifndef BROWSERZOOMWIDGET_H
+#define BROWSERZOOMWIDGET_H
+
+#include <QWidget>
+
+class QPushButton;
+class QLabel;
+
+class BrowserZoomWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit BrowserZoomWidget(QWidget *parent = nullptr);
+    QPushButton *zoomOutButton();
+    QPushButton *zoomInButton();
+    QPushButton *resetZoomButton();
+    QLabel *zoomLevelLabel();
+
+private:
+    QPushButton *m_zoomOutButton{nullptr};
+    QPushButton *m_zoomInButton{nullptr};
+    QPushButton *m_resetZoomButton{nullptr};
+    QLabel *m_zoomLevelLabel{nullptr};
+};
+
+#endif // BROWSERZOOMWIDGETACTION_H

--- a/src/libs/ui/widgets/browserzoomwidget.h
+++ b/src/libs/ui/widgets/browserzoomwidget.h
@@ -1,26 +1,34 @@
-#ifndef BROWSERZOOMWIDGET_H
-#define BROWSERZOOMWIDGET_H
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ZEAL_WIDGETUI_BROWSERZOOMWIDGET_H
+#define ZEAL_WIDGETUI_BROWSERZOOMWIDGET_H
 
 #include <QWidget>
 
-class QPushButton;
 class QLabel;
 
-class BrowserZoomWidget : public QWidget
+namespace Zeal::WidgetUi {
+
+class BrowserZoomWidget final : public QWidget
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(BrowserZoomWidget)
 public:
     explicit BrowserZoomWidget(QWidget *parent = nullptr);
-    QPushButton *zoomOutButton();
-    QPushButton *zoomInButton();
-    QPushButton *resetZoomButton();
-    QLabel *zoomLevelLabel();
+    ~BrowserZoomWidget() override = default;
+
+    void setZoomPercentage(int percent);
+
+signals:
+    void zoomInRequested();
+    void zoomOutRequested();
+    void resetZoomRequested();
 
 private:
-    QPushButton *m_zoomOutButton{nullptr};
-    QPushButton *m_zoomInButton{nullptr};
-    QPushButton *m_resetZoomButton{nullptr};
-    QLabel *m_zoomLevelLabel{nullptr};
+    QLabel *m_levelLabel = nullptr;
 };
 
-#endif // BROWSERZOOMWIDGETACTION_H
+} // namespace Zeal::WidgetUi
+
+#endif // ZEAL_WIDGETUI_BROWSERZOOMWIDGET_H


### PR DESCRIPTION
As requested in #1256, I added zoom in, zoom out and reset zoom items to the edit menu. Two convenient tool buttons for zoom in and zoom out were added to browser tab as well. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zoom controls to the View menu (Zoom In, Zoom Out, Actual Size) with keyboard shortcuts
  * Introduced a per-tab zoom widget (toolbar menu) showing the current zoom percentage and offering Zoom In/Out and Reset
  * Zoom levels now update in real time across tabs so displayed percentages stay in sync
<!-- end of auto-generated comment: release notes by coderabbit.ai -->