### PR TITLE
build(sidebar): add missing STATIC keyword

### DIFF
--- a/src/libs/sidebar/CMakeLists.txt
+++ b/src/libs/sidebar/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Sidebar
+add_library(Sidebar STATIC
     container.cpp
     proxyview.cpp
     view.cpp


### PR DESCRIPTION
Fixes unresolved soname dependency after install.