### PR TITLE
fix(assets): prevent duplicating application icons in GNOME dock

### DIFF
--- a/assets/freedesktop/org.zealdocs.Zeal.desktop
+++ b/assets/freedesktop/org.zealdocs.Zeal.desktop
@@ -9,3 +9,4 @@ Terminal=false
 Type=Application
 Categories=Development;
 MimeType=x-scheme-handler/dash;x-scheme-handler/dash-plugin;
+StartupWMClass=Zeal


### PR DESCRIPTION
Currently, Zeal has a problem with duplicating the application icon when opening the application in Linux GNOME environment.

Exact the same problem in the following link.
https://askubuntu.com/questions/975178/duplicate-application-icons-in-ubuntu-dock-upon-launch

In order to solve this problem, we need to specify `StartupWMClass=Zeal` in `org.zealdocs.Zeal.desktop`