### PR TITLE
fix(browser): prevent WebEngine taking away focus from searchbox

### DIFF
--- a/src/libs/browser/webview.cpp
+++ b/src/libs/browser/webview.cpp
@@ -41,6 +41,7 @@
 #include <QVector>
 #include <QWebEngineContextMenuData>
 #include <QWebEngineProfile>
+#include <QWebEngineSettings>
 #include <QWheelEvent>
 
 using namespace Zeal::Browser;
@@ -50,6 +51,8 @@ WebView::WebView(QWidget *parent)
 {
     setPage(new WebPage(this));
     setZoomLevel(defaultZoomLevel());
+
+    settings()->setAttribute(QWebEngineSettings::FocusOnNavigationEnabled, false);
 
     QApplication::instance()->installEventFilter(this);
 }


### PR DESCRIPTION
Version on master doesn't let me enter search with pauses or switch among results. Browser takes the focus away from the search box each time it's updated.

Happens since 5360da3d7f34906ff41c10ac74e6b01636598903.