### PR TITLE
Add Ctrl+N and Ctrl+P keys to the search box

### DIFF
--- a/src/libs/ui/searchsidebar.cpp
+++ b/src/libs/ui/searchsidebar.cpp
@@ -393,7 +393,21 @@ bool SearchSidebar::eventFilter(QObject *object, QEvent *event)
         case Qt::Key_PageUp:
             QCoreApplication::sendEvent(m_treeView, event);
             break;
+        }
 
+        if (e->modifiers() == Qt::ControlModifier) {
+            switch (e->key()) {
+            case Qt::Key_N: {
+                QKeyEvent newEvent(QKeyEvent::KeyPress, Qt::Key_Down, Qt::NoModifier);
+                QCoreApplication::sendEvent(m_treeView, &newEvent);
+                break;
+            }
+            case Qt::Key_P: {
+                QKeyEvent newEvent(QKeyEvent::KeyPress, Qt::Key_Up, Qt::NoModifier);
+                QCoreApplication::sendEvent(m_treeView, &newEvent);
+                break;
+            }
+            }
         }
     }
 


### PR DESCRIPTION
Provide <kbd>Ctrl+N</kbd> and <kbd>Ctrl+P</kbd> keys as equivalents for <kbd>Down</kbd> and <kbd>Up</kbd> keys. Similar to how it works in various other search boxes, e.g. in QtCreator's magic box.