### PR TITLE
fix: Include system CA certificates in requests

### DIFF
--- a/src/libs/core/networkaccessmanager.cpp
+++ b/src/libs/core/networkaccessmanager.cpp
@@ -71,5 +71,9 @@ QNetworkReply *NetworkAccessManager::createRequest(QNetworkAccessManager::Operat
         op = QNetworkAccessManager::GetOperation;
     }
 
+    QSslConfiguration sslConfig = overrideRequest.sslConfiguration();
+    sslConfig.setCaCertificates(QSslConfiguration::systemCaCertificates());
+    overrideRequest.setSslConfiguration(sslConfig);
+
     return QNetworkAccessManager::createRequest(op, overrideRequest, outgoingData);
 }


### PR DESCRIPTION
On Fedora 34, I've built Zeal with Qt5.15.2 and OpenSSL-1.1.1l.

When trying to check for updates, the request fails with "SSL handshake error". I can also reproduce this issue in one of the [Qt examples](https://code.qt.io/cgit/qt/qtbase.git/tree/examples/network/http?h=5.15), which includes the more descriptive message "The issuer certificate of a locally looked up certificate could not be found".

The root cause seems to be the same as described in [another issue](https://github.com/owncloud/client/issues/1540): If I run `strace` on `zeal`, I confirm that it doesn't access my certificate bundle (`/etc/pki/tls/certs/ca-bundle.crt`), instead it tries to lookup `c_rehash` generated files that aren't present.

Regardless of which files are present, Zeal can be resilient to these cases and load the certificate bundle explicitly. My pull request accomplishes that by using `QSslConfiguration`'s built-in method that provides those system certificates. This way, the peer certificate chain can be verified and no SSL handshake error is thrown.