### PR TITLE
feat: add option to hide menubar

### DIFF
--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -95,6 +95,8 @@ void Settings::load()
     minimizeToSystray = settings->value(QStringLiteral("minimize_to_systray"), false).toBool();
     hideOnClose = settings->value(QStringLiteral("hide_on_close"), false).toBool();
 
+    hideMenuBar = settings->value(QStringLiteral("hide_menu_bar"), false).toBool();
+
     settings->beginGroup(GroupGlobalShortcuts);
     showShortcut = settings->value(QStringLiteral("show")).value<QKeySequence>();
     settings->endGroup();
@@ -226,6 +228,8 @@ void Settings::save()
     settings->setValue(QStringLiteral("show_systray_icon"), showSystrayIcon);
     settings->setValue(QStringLiteral("minimize_to_systray"), minimizeToSystray);
     settings->setValue(QStringLiteral("hide_on_close"), hideOnClose);
+
+    settings->setValue(QStringLiteral("hide_menu_bar"), hideMenuBar);
 
     settings->beginGroup(GroupGlobalShortcuts);
     settings->setValue(QStringLiteral("show"), showShortcut);

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -39,6 +39,9 @@ public:
     // Tabs Behavior
     bool openNewTabAfterActive;
 
+    // Appearance
+    bool hideMenuBar;
+
     // Search
     bool isFuzzySearchEnabled;
 

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -135,6 +135,19 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent)
         dialog->exec();
     });
 
+    // View Menu
+    ui->actionHideMenu->setShortcut(QStringLiteral("Ctrl+m"));
+    connect(ui->actionHideMenu, &QAction::triggered, this, [this]() {
+        if (ui->menuBar->isVisible()) {
+            m_settings->hideMenuBar = true;
+        }
+        else {
+            m_settings->hideMenuBar = false;
+        }
+        applySettings();
+    });
+    addAction(ui->actionHideMenu);
+
     // Help Menu
     connect(ui->actionSubmitFeedback, &QAction::triggered, []() {
         QDesktopServices::openUrl(QUrl(QStringLiteral("https://github.com/zealdocs/zeal/issues")));
@@ -512,6 +525,13 @@ void MainWindow::applySettings()
 {
     if (m_globalShortcut) {
         m_globalShortcut->setShortcut(m_settings->showShortcut);
+    }
+
+    if (m_settings->hideMenuBar){
+        ui->menuBar->hide();
+    }
+    else {
+        ui->menuBar->show();
     }
 
     if (m_settings->showSystrayIcon)

--- a/src/libs/ui/mainwindow.ui
+++ b/src/libs/ui/mainwindow.ui
@@ -94,6 +94,12 @@
     <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="actionHideMenu"/>
+   </widget>
    <widget class="QMenu" name="menu_Tools">
     <property name="title">
      <string>&amp;Tools</string>
@@ -102,6 +108,7 @@
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menu_Edit"/>
+   <addaction name="menu_View"/>
    <addaction name="menu_Tools"/>
    <addaction name="menuHelp"/>
   </widget>
@@ -173,6 +180,11 @@
    </property>
    <property name="text">
     <string>&amp;Find</string>
+   </property>
+  </action>
+  <action name="actionHideMenu">
+   <property name="text">
+    <string>&amp;Hide menubar</string>
    </property>
   </action>
   <action name="actionDocsets">


### PR DESCRIPTION
I added a "View" submenu to the menubar, that allows the user hide the menubar. I also added a keyboard shortcut (`Ctrl + M`, as suggested in issue #1251) to toggle the visibility of the menubar. This preference is saved, so it can be restored once the user closes and reopens Zeal.

This preference is tipically only accessible in the "View" submenu, so I didn't add an entry for it in the "Preferences" window. I could do that as well, if you prefer.

I haven't been able to show/hide the menubar when `Alt` is pressed/released though, so this isn't ready. I decided to create this draft PR anyways, in case someone else knows how to that, since it would solve issue #1251 and make progress towards solving issue #1202.

https://user-images.githubusercontent.com/65264536/201760101-b4d640a0-7b9b-42a1-a3cd-3df964d084e5.mp4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a View menu with a "Hide menubar" toggle to quickly show or hide the menu bar.
  * Preference persists across sessions so your chosen visibility is remembered on restart.
  * Keyboard shortcut: Ctrl+M to toggle the menubar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->