### PR TITLE
chore(gitignore): add CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 CMakeLists.txt.user
 build/
 build.*/
+CMakeUserPresets.json
 
 # AppImage Builder
 *.AppImage


### PR DESCRIPTION
Hi for my personal builds I added a couple of presets to the `CMakeUserPresets.json` file which is not meant to be commited so I can build with MSVC on Windows.

These are the presets that I'm using (VS Code does not enable the MSVC compiler unless you define the toolset and architecture values):

```json
{
    "name": "MSVC",
    "displayName": "MSVC",
    "description": "Use the Visual Studio compiler",
    "cacheVariables": {
        "CMAKE_CXX_COMPILER": "cl",
        "CMAKE_C_COMPILER": "cl"
    },
    "architecture": {
        "value": "x64",
        "strategy": "external"
    },
    "toolset": {
        "value": "host=x64",
        "strategy": "external"
    }
},
{
    "name": "ninja-multi-vcpkg-MSVC",
    "displayName": "UVCPKG",
    "description": "Use the Visual Studio compiler",
    "inherits": ["ninja-multi-vcpkg", "MSVC"]
}
```