### PR TITLE
chore: remove unused methods

### DIFF
--- a/src/libs/core/application.cpp
+++ b/src/libs/core/application.cpp
@@ -150,16 +150,6 @@ QString Application::cacheLocation()
 #endif
 }
 
-QString Application::configLocation()
-{
-#ifndef PORTABLE_BUILD
-    // TODO: Replace 'Zeal/Zeal' with 'zeal'.
-    return QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-#else
-    return QCoreApplication::applicationDirPath() + QLatin1String("/config");
-#endif
-}
-
 QVersionNumber Application::version()
 {
     static const auto vn = QVersionNumber::fromString(QCoreApplication::applicationVersion());

--- a/src/libs/core/application.h
+++ b/src/libs/core/application.h
@@ -68,7 +68,6 @@ public:
     HttpServer *httpServer() const;
 
     static QString cacheLocation();
-    static QString configLocation();
     static QVersionNumber version();
     static QString versionString();
 

--- a/src/libs/registry/docsetmetadata.cpp
+++ b/src/libs/registry/docsetmetadata.cpp
@@ -145,11 +145,6 @@ QStringList DocsetMetadata::aliases() const
     return m_aliases;
 }
 
-QStringList DocsetMetadata::versions() const
-{
-    return m_versions;
-}
-
 QString DocsetMetadata::latestVersion() const
 {
     return m_versions.isEmpty() ? QString() : m_versions.first();

--- a/src/libs/registry/docsetmetadata.h
+++ b/src/libs/registry/docsetmetadata.h
@@ -43,7 +43,6 @@ public:
     QString name() const;
     QString title() const;
     QStringList aliases() const;
-    QStringList versions() const;
     QString latestVersion() const;
     QString revision() const;
     QIcon icon() const;

--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -111,11 +111,6 @@ bool DocsetRegistry::contains(const QString &name) const
     return m_docsets.contains(name);
 }
 
-QStringList DocsetRegistry::names() const
-{
-    return m_docsets.keys();
-}
-
 void DocsetRegistry::loadDocset(const QString &path)
 {
     std::future<Docset *> f = std::async(std::launch::async, [path](){

--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -106,11 +106,6 @@ void DocsetRegistry::setFuzzySearchEnabled(bool enabled)
     }
 }
 
-int DocsetRegistry::count() const
-{
-    return m_docsets.count();
-}
-
 bool DocsetRegistry::contains(const QString &name) const
 {
     return m_docsets.contains(name);

--- a/src/libs/registry/docsetregistry.h
+++ b/src/libs/registry/docsetregistry.h
@@ -55,7 +55,6 @@ public:
     void setFuzzySearchEnabled(bool enabled);
 
     bool contains(const QString &name) const;
-    QStringList names() const;
 
     void loadDocset(const QString &path);
     void unloadDocset(const QString &name);

--- a/src/libs/registry/docsetregistry.h
+++ b/src/libs/registry/docsetregistry.h
@@ -54,7 +54,6 @@ public:
     bool isFuzzySearchEnabled() const;
     void setFuzzySearchEnabled(bool enabled);
 
-    int count() const;
     bool contains(const QString &name) const;
     QStringList names() const;
 


### PR DESCRIPTION
This PR removes unused functions and class methods.

I ran keepassxc through [xunused](https://github.com/mgehre/xunused), manually inspected the results to remove false positives, and then removed the code that seems to actually be unused.