### PR TITLE
fix(ui): replace QKeySequence::NextChild with manual shortcut

### DIFF
--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -221,14 +221,15 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent)
     addAction(ui->actionCloseTab);
     connect(ui->actionCloseTab, &QAction::triggered, this, [this]() { closeTab(); });
 
-    ui->actionNextTab->setShortcuts({QKeySequence::NextChild,
+    // TODO: Use QKeySequence::PreviousChild & NextChild, when QTBUG-112193 is fixed.
+    ui->actionNextTab->setShortcuts({QKeySequence(Qt::ControlModifier | Qt::Key_Tab),
                                      QKeySequence(Qt::ControlModifier | Qt::Key_PageDown)});
     addAction(ui->actionNextTab);
     connect(ui->actionNextTab, &QAction::triggered, this, [this]() {
         m_tabBar->setCurrentIndex((m_tabBar->currentIndex() + 1) % m_tabBar->count());
     });
 
-    // TODO: Use QKeySequence::PreviousChild, when QTBUG-15746 is fixed.
+    // TODO: Use QKeySequence::PreviousChild & NextChild, when QTBUG-112193 is fixed.
     ui->actionPreviousTab->setShortcuts({QKeySequence(Qt::ControlModifier | Qt::ShiftModifier | Qt::Key_Tab),
                                          QKeySequence(Qt::ControlModifier | Qt::Key_PageUp)});
     addAction(ui->actionPreviousTab);

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -229,7 +229,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent)
         m_tabBar->setCurrentIndex((m_tabBar->currentIndex() + 1) % m_tabBar->count());
     });
 
-    // TODO: Use QKeySequence::PreviousChild & NextChild, when QTBUG-112193 is fixed.
+    // TODO: Use QKeySequence::PreviousChild, when QTBUG-15746 and QTBUG-112193 are fixed.
     ui->actionPreviousTab->setShortcuts({QKeySequence(Qt::ControlModifier | Qt::ShiftModifier | Qt::Key_Tab),
                                          QKeySequence(Qt::ControlModifier | Qt::Key_PageUp)});
     addAction(ui->actionPreviousTab);

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -221,7 +221,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent)
     addAction(ui->actionCloseTab);
     connect(ui->actionCloseTab, &QAction::triggered, this, [this]() { closeTab(); });
 
-    // TODO: Use QKeySequence::PreviousChild & NextChild, when QTBUG-112193 is fixed.
+    // TODO: Use QKeySequence::NextChild, when QTBUG-112193 is fixed.
     ui->actionNextTab->setShortcuts({QKeySequence(Qt::ControlModifier | Qt::Key_Tab),
                                      QKeySequence(Qt::ControlModifier | Qt::Key_PageDown)});
     addAction(ui->actionNextTab);


### PR DESCRIPTION
Qt internally can not de-duplicate standard shortcuts like QKeySequence::NextChild and manually specified Ctrl+PageDown which are practically the same thing on default KDE/Plasma installations.

Fixes #1465