### PR TITLE
chore(gitignore): add vcpkg and vcpkg_install directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,3 @@ squashfs-root/
 # vcpkg
 vcpkg/
 vcpkg_installed/
-

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ squashfs-root/
 # Linux appdata
 /assets/freedesktop/org.zealdocs.zeal.appdata.xml
 
-# Vcpkg
+# vcpkg
 vcpkg/
 vcpkg_installed/
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ squashfs-root/
 
 # Linux appdata
 /assets/freedesktop/org.zealdocs.zeal.appdata.xml
+
+# Vcpkg
+vcpkg/
+vcpkg_installed/
+


### PR DESCRIPTION
Some people build zeal with local installed vcpkg. vcpkg will build dependencies into vcpkg_installed folder.