### PR TITLE
feat(browser): use native Chromium dark mode

### DIFF
--- a/src/libs/browser/settings.cpp
+++ b/src/libs/browser/settings.cpp
@@ -72,9 +72,17 @@ void Settings::applySettings()
     // TODO: Apply to all open pages.
     m_webProfile->scripts()->clear(); // Remove all scripts first.
 
-    if (m_appSettings->isDarkModeEnabled) {
+    // Qt 5.14+ uses native Chromium dark mode.
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    const bool enableDarkMode
+        = m_appSettings->contentAppearance == Core::Settings::ContentAppearance::Dark
+          || (m_appSettings->contentAppearance == Core::Settings::ContentAppearance::Automatic
+              && m_appSettings->colorScheme() == Core::Settings::ColorScheme::Dark);
+
+    if (enableDarkMode) {
         setCustomStyleSheet(QStringLiteral("_zeal_darkstylesheet"), DarkModeCssUrl);
     }
+#endif
 
     if (m_appSettings->isHighlightOnNavigateEnabled) {
         setCustomStyleSheet(QStringLiteral("_zeal_highlightstylesheet"), HighlightOnNavigateCssUrl);

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -79,7 +79,14 @@ public:
     Q_ENUM(ExternalLinkPolicy)
     ExternalLinkPolicy externalLinkPolicy = ExternalLinkPolicy::Ask;
 
-    bool isDarkModeEnabled;
+    enum class ContentAppearance : unsigned int {
+        Automatic = 0,
+        Light,
+        Dark
+    };
+    Q_ENUM(ContentAppearance)
+    ContentAppearance contentAppearance = ContentAppearance::Automatic;
+
     bool isHighlightOnNavigateEnabled;
     QString customCssFile;
     bool isSmoothScrollingEnabled;
@@ -117,6 +124,19 @@ public:
 
     explicit Settings(QObject *parent = nullptr);
     ~Settings() override;
+
+    // Helper functions.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    typedef Qt::ColorScheme ColorScheme;
+#else
+    enum class ColorScheme {
+        Unknown,
+        Light,
+        Dark,
+    };
+#endif
+
+    static ColorScheme colorScheme();
 
 public slots:
     void load();

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -203,7 +203,18 @@ void SettingsDialog::loadSettings()
     ui->fixedFontSizeComboBox->setCurrentText(QString::number(settings->defaultFixedFontSize));
     ui->minFontSizeComboBox->setCurrentText(QString::number(settings->minimumFontSize));
 
-    ui->darkModeCheckBox->setChecked(settings->isDarkModeEnabled);
+    switch (settings->contentAppearance) {
+    case Core::Settings::ContentAppearance::Automatic:
+        ui->appearanceAutoRadioButton->setChecked(true);
+        break;
+    case Core::Settings::ContentAppearance::Light:
+        ui->appearanceLightRadioButton->setChecked(true);
+        break;
+    case Core::Settings::ContentAppearance::Dark:
+        ui->appearanceDarkRadioButton->setChecked(true);
+        break;
+    }
+
     ui->highlightOnNavigateCheckBox->setChecked(settings->isHighlightOnNavigateEnabled);
     ui->customCssFileEdit->setText(QDir::toNativeSeparators(settings->customCssFile));
 
@@ -278,7 +289,14 @@ void SettingsDialog::saveSettings()
     settings->defaultFixedFontSize = ui->fixedFontSizeComboBox->currentData().toInt();
     settings->minimumFontSize = ui->minFontSizeComboBox->currentData().toInt();
 
-    settings->isDarkModeEnabled = ui->darkModeCheckBox->isChecked();
+    if (ui->appearanceAutoRadioButton->isChecked()) {
+        settings->contentAppearance = Core::Settings::ContentAppearance::Automatic;
+    } else if (ui->appearanceLightRadioButton->isChecked()) {
+        settings->contentAppearance = Core::Settings::ContentAppearance::Light;
+    } else if (ui->appearanceDarkRadioButton->isChecked()) {
+        settings->contentAppearance = Core::Settings::ContentAppearance::Dark;
+    }
+
     settings->isHighlightOnNavigateEnabled = ui->highlightOnNavigateCheckBox->isChecked();
     settings->customCssFile = QDir::fromNativeSeparators(ui->customCssFileEdit->text());
 

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -241,6 +241,98 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
+        <widget class="QGroupBox" name="styleGroupBox">
+         <property name="title">
+          <string>Style</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_17">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="appearanceLabel">
+              <property name="text">
+               <string>Appearance (requires restart):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="appearanceAutoRadioButton">
+              <property name="text">
+               <string>A&amp;utomatic</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="appearanceLightRadioButton">
+              <property name="text">
+               <string>&amp;Light</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="appearanceDarkRadioButton">
+              <property name="text">
+               <string>&amp;Dark</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="customCssFileLabel">
+              <property name="text">
+               <string>&amp;Custom CSS file:</string>
+              </property>
+              <property name="buddy">
+               <cstring>customCssFileEdit</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="customCssFileEdit">
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="customCssFileBrowseButton">
+              <property name="text">
+               <string>Bro&amp;wse…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="highlightOnNavigateCheckBox">
+            <property name="text">
+             <string>&amp;Highlight on navigate</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="fontsGroupBox">
          <property name="title">
           <string>Fonts</string>
@@ -399,57 +491,6 @@
             </item>
             <item>
              <widget class="QComboBox" name="minFontSizeComboBox"/>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="styleGroupBox">
-         <property name="title">
-          <string>Style</string>
-         </property>
-         <layout class="QFormLayout" name="formLayout_5">
-          <item row="1" column="0" colspan="2">
-           <widget class="QCheckBox" name="darkModeCheckBox">
-            <property name="text">
-             <string>&amp;Dark mode</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="highlightOnNavigateCheckBox">
-            <property name="text">
-             <string>&amp;Highlight on navigate</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QLabel" name="customCssFileLabel">
-              <property name="text">
-               <string>&amp;Custom CSS file:</string>
-              </property>
-              <property name="buddy">
-               <cstring>customCssFileEdit</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="customCssFileEdit">
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="customCssFileBrowseButton">
-              <property name="text">
-               <string>Bro&amp;wse…</string>
-              </property>
-             </widget>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
Switch to Chromium's dark mode instead of CSS hacks. More information is available in [QTBUG-72028](https://bugreports.qt.io/browse/QTBUG-72028). By default Zeal will try to follow system's color mode.

CSS hack is kept around for builds with Qt version lower than 5.12 (hi, Ubuntu 20.04), and will be removed in one of the future releases.  

Currently there's no way to enable dark mode without restart. See [QTBUG-84484](https://bugreports.qt.io/browse/QTBUG-84484).
