### PR TITLE
feat(ui): use Fusion style on Windows 10 & 11

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -189,6 +189,16 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
+// Use Fusion style on Windows 10 & 11. This enables proper darl mode support.
+// See https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5.
+// TODO: Make style configurable, detect -style argument.
+#if defined(Q_OS_WIN) && (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    const auto osName = QSysInfo::prettyProductName();
+    if (osName.startsWith("Windows 10") || osName.startsWith("Windows 11")) {
+        QApplication::setStyle("fusion");
+    }
+#endif
+
     QScopedPointer<QApplication> qapp(new QApplication(argc, argv));
 
     const CommandLineParameters clParams = parseCommandLine(qapp->arguments());


### PR DESCRIPTION
This enables dark mode support.

Fixes #811.