### PR TITLE
Add a screenshot taken on a Linux desktop for Linux app stores

### DIFF
--- a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+++ b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
@@ -19,7 +19,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>The main window</caption>
-      <image>https://i.imgur.com/qBkZduS.png</image>
+      <image>https://community.linuxmint.com/img/screenshots/zeal.png</image>
     </screenshot>
   </screenshots>
   <provides>


### PR DESCRIPTION
as the existing Windows 10 based one is odd on places like https://flathub.org/apps/org.zealdocs.Zeal