### PR TITLE
treewide: replace deprecated qAsConst with std::as_const()

### DIFF
--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -458,7 +458,7 @@ void Docset::loadSymbols(const QString &symbolType) const
     // with it.first and it.second respectively pointing to the start and the end
     // of the range of nodes having symbolType as key. It effectively represents a
     // contiguous view over the nodes with a specified key.
-    for (auto it = qAsConst(m_symbolStrings).equal_range(symbolType); it.first != it.second; ++it.first) {
+    for (auto it = std::as_const(m_symbolStrings).equal_range(symbolType); it.first != it.second; ++it.first) {
         loadSymbols(symbolType, it.first.value());
     }
 }
@@ -519,7 +519,7 @@ void Docset::createIndex()
     }
 
     // Drop old indexes
-    for (const QString &oldIndexName : qAsConst(oldIndexes)) {
+    for (const QString &oldIndexName : std::as_const(oldIndexes)) {
         m_db->execute(indexDropQuery.arg(oldIndexName));
     }
 

--- a/src/libs/registry/docsetmetadata.cpp
+++ b/src/libs/registry/docsetmetadata.cpp
@@ -97,7 +97,7 @@ void DocsetMetadata::save(const QString &path, const QString &version)
 
     if (!m_urls.isEmpty()) {
         QJsonArray urls;
-        for (const QUrl &url : qAsConst(m_urls)) {
+        for (const QUrl &url : std::as_const(m_urls)) {
             urls.append(url.toString());
         }
 

--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -101,7 +101,7 @@ void DocsetRegistry::setFuzzySearchEnabled(bool enabled)
 
     m_isFuzzySearchEnabled = enabled;
 
-    for (Docset *docset : qAsConst(m_docsets)) {
+    for (Docset *docset : std::as_const(m_docsets)) {
         docset->setFuzzySearchEnabled(enabled);
     }
 }
@@ -193,7 +193,7 @@ Docset *DocsetRegistry::docset(int index) const
 
 Docset *DocsetRegistry::docsetForUrl(const QUrl &url)
 {
-    for (Docset *docset : qAsConst(m_docsets)) {
+    for (Docset *docset : std::as_const(m_docsets)) {
         if (docset->baseUrl().isParentOf(url))
             return docset;
     }
@@ -226,7 +226,7 @@ void DocsetRegistry::_runQuery(const QString &query)
 
     const SearchQuery searchQuery = SearchQuery::fromString(query);
     if (searchQuery.hasKeywords()) {
-        for (Docset *docset : qAsConst(m_docsets)) {
+        for (Docset *docset : std::as_const(m_docsets)) {
             if (searchQuery.hasKeywords(docset->keywords()))
                 enabledDocsets << docset;
         }

--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -687,7 +687,7 @@ QNetworkReply *DocsetsDialog::download(const QUrl &url)
 
 void DocsetsDialog::cancelDownloads()
 {
-    for (QNetworkReply *reply : qAsConst(m_replies)) {
+    for (QNetworkReply *reply : std::as_const(m_replies)) {
         // Hide progress bar
         QListWidgetItem *listItem
                 = ui->availableDocsetList->item(reply->property(ListItemIndexProperty).toInt());

--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
@@ -152,7 +152,7 @@ bool QxtGlobalShortcutPrivate::registerShortcut(quint32 nativeKey, quint32 nativ
     }
 
     bool failed = false;
-    for (xcb_void_cookie_t cookie : qAsConst(xcbCookies)) {
+    for (xcb_void_cookie_t cookie : std::as_const(xcbCookies)) {
         QScopedPointer<xcb_generic_error_t, QScopedPointerPodDeleter> error(xcb_request_check(xcbConnection, cookie));
         failed = !error.isNull();
     }


### PR DESCRIPTION
Reference: https://github.com/qt/qtbase/blob/v6.6.0/src/corelib/global/qttypetraits.h#L32

Tested building with qt 6.6.0, 6.5.3 and 5.15.10