### PR TITLE
linux: minor appdata-related changes

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -202,6 +202,7 @@ jobs:
             ninja-build
             qtbase5-dev
             qtwebengine5-dev
+            appstream-util
 
       - name: Upload AppImage
         uses: actions/upload-artifact@v3

--- a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+++ b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
@@ -34,33 +34,5 @@
     </release>
   </releases>
   <update_contact>support@zealdocs.org</update_contact>
-  <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
+  <content_rating type="oars-1.1" />
 </component>

--- a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+++ b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
@@ -19,7 +19,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>The main window</caption>
-      <image>https://i.imgur.com/qBkZduS.png</image>
+      <image>https://i.imgur.com/FvGEguY.png</image>
     </screenshot>
   </screenshots>
   <provides>

--- a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+++ b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
@@ -26,8 +26,12 @@
     <id>zeal.desktop</id>
   </provides>
   <releases>@ZEAL_APPSTREAM_DEV_RELEASE@
-    <release date="2023-09-20" version="0.7.0" type="stable" />
-    <release date="2018-09-28" version="0.6.1" type="stable" />
+    <release date="2023-09-20" version="0.7.0" type="stable">
+      <url>https://github.com/zealdocs/zeal/releases/tag/v0.7.0</url>
+    </release>
+    <release date="2018-09-28" version="0.6.1" type="stable">
+      <url>https://github.com/zealdocs/zeal/releases/tag/v0.6.1</url>
+    </release>
   </releases>
   <update_contact>support@zealdocs.org</update_contact>
   <content_rating type="oars-1.1">

--- a/pkg/appimage/appimage-amd64.yaml
+++ b/pkg/appimage/appimage-amd64.yaml
@@ -4,6 +4,7 @@ script:
   - cmake -B $BUILD_DIR/cmake-build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
   - cmake --build $BUILD_DIR/cmake-build
   - cmake --install $BUILD_DIR/cmake-build --prefix $TARGET_APPDIR/usr
+  - appstream-util validate-relax $TARGET_APPDIR/usr/share/metainfo/org.zealdocs.zeal.appdata.xml
 
 AppDir:
   app_info:


### PR DESCRIPTION
This PR mainly introduces a handful of minor changes to the Linux AppStream metadata file:

- Replace the Windows screenshot by one taken on Linux
- Add link to release notes, which can be shown on Linux app stores, such as Flathub
- Simplify the content rating ([OARS](https://hughsie.github.io/oars/generate.html)) section
- Validate the Linux AppStream metadata file using GitHub Actions