### PR TITLE
linux: more appdata-related changes

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -202,7 +202,7 @@ jobs:
             ninja-build
             qtbase5-dev
             qtwebengine5-dev
-            appstream-util
+            appstream
 
       - name: Upload AppImage
         uses: actions/upload-artifact@v4

--- a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+++ b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
@@ -5,7 +5,9 @@
   <name>Zeal</name>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  <developer_name>Oleg Shparber</developer_name>
+  <developer id="org.zealdocs">
+    <name>Oleg Shparber</name>
+  </developer>
   <summary>Documentation browser</summary>
   <description>
     <p>Zeal is a simple offline documentation browser inspired by Dash. It offers access to over 200 docsets covering various libraries and APIs.</p>

--- a/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
+++ b/assets/freedesktop/org.zealdocs.zeal.appdata.xml.in
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>org.zealdocs.zeal</id>
+  <launchable type="desktop-id">org.zealdocs.zeal.desktop</launchable>
   <name>Zeal</name>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>

--- a/pkg/appimage/appimage-amd64.yaml
+++ b/pkg/appimage/appimage-amd64.yaml
@@ -4,7 +4,7 @@ script:
   - cmake -B $BUILD_DIR/cmake-build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
   - cmake --build $BUILD_DIR/cmake-build
   - cmake --install $BUILD_DIR/cmake-build --prefix $TARGET_APPDIR/usr
-  - appstream-util validate-relax $TARGET_APPDIR/usr/share/metainfo/org.zealdocs.zeal.appdata.xml
+  - appstreamcli validate $TARGET_APPDIR/usr/share/metainfo/org.zealdocs.zeal.appdata.xml
 
 AppDir:
   app_info:


### PR DESCRIPTION
These changes are mostly relevant for Flathub, as they've recently [transitioned](https://docs.flathub.org/blog/improved-build-validation/) to a more modern AppStream metadata validation tool, and this PR aims to abide to these new validation rules.