### PR TITLE
chore(cmake,ui): update copyright year

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 # Project information.
 set(PROJECT_COMPANY_NAME "Oleg Shparber")
-set(PROJECT_COPYRIGHT "© 2013-2023 Oleg Shparber and other contributors")
+set(PROJECT_COPYRIGHT "© 2013-2024 Oleg Shparber and other contributors")
 
 # Find available major Qt version. It will be stored in QT_VERSION_MAJOR.
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)

--- a/src/libs/ui/aboutdialog.ui
+++ b/src/libs/ui/aboutdialog.ui
@@ -78,7 +78,7 @@
          <property name="text">
           <string>&lt;strong&gt;A simple offline documentation browser&lt;/strong&gt;
 &lt;br&gt;&lt;br&gt;
-Copyright &amp;copy; Oleg Shparber and other contributors, 2013-2023.
+Copyright &amp;copy; Oleg Shparber and other contributors, 2013-2024.
 &lt;br&gt;
 &lt;a href=&quot;https://zealdocs.org&quot;&gt;zealdocs.org&lt;/a&gt;
 &lt;br&gt;


### PR DESCRIPTION
Just tried this v0.7.1 . This PR fix copyright year in CMakeLists.txt and UI's about page:

![image](https://github.com/zealdocs/zeal/assets/3831847/029d236e-37ca-4836-b1bd-bba0a60996dd)
