### PR TITLE
build(app): add missing Qt components to find_package

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}
+    COMPONENTS Concurrent Network WebChannel WebEngineWidgets Widgets
+    REQUIRED)
 if (Qt${QT_VERSION_MAJOR}Widgets_VERSION VERSION_LESS QT_MINIMUM_VERSION)
     message(FATAL_ERROR "Qt version >= ${QT_MINIMUM_VERSION} is required.")
 endif()

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,6 +1,4 @@
-find_package(Qt${QT_VERSION_MAJOR}
-    COMPONENTS Concurrent Network WebChannel WebEngineWidgets Widgets
-    REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Concurrent WebEngineWidgets Widgets REQUIRED)
 if (Qt${QT_VERSION_MAJOR}Widgets_VERSION VERSION_LESS QT_MINIMUM_VERSION)
     message(FATAL_ERROR "Qt version >= ${QT_MINIMUM_VERSION} is required.")
 endif()


### PR DESCRIPTION
Fixes #1643.

Starting from Qt 6.7.2 it is necessary to list all necessary components for Qt6 rather than deferring them. This commit fixes a build failure when cmake configures a build against Qt >= 6.7.2, where we otherwise see a failure like:

```
[   14s] CMake Error at
/usr/lib64/cmake/Qt6/QtPublicWalkLibsHelpers.cmake:259 (message):
[   14s]   The Concurrent target is mentioned as a dependency for
Registry, but not
[   14s]   declared.
[   14s] Call Stack (most recent call first):
[   14s]   /usr/lib64/cmake/Qt6/QtPublicWalkLibsHelpers.cmake:228
(__qt_internal_walk_libs)
[   14s]   /usr/lib64/cmake/Qt6/QtPublicWalkLibsHelpers.cmake:311
(__qt_internal_walk_libs)
[   14s]   /usr/lib64/cmake/Qt6Core/Qt6CoreMacros.cmake:651
(__qt_internal_collect_all_target_dependencies)
[   14s]   /usr/lib64/cmake/Qt6Core/Qt6CoreMacros.cmake:774
(_qt_internal_finalize_executable)
[   14s]   /usr/lib64/cmake/Qt6Core/Qt6CoreMacros.cmake:590:EVAL:1
(qt6_finalize_target)
[   14s]   src/app/CMakeLists.txt:DEFERRED
```

and so on for all missing components.