### PR TITLE
fix(registry): add missing error logging

### DIFF
--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -64,9 +64,10 @@ Docset::Docset(QString path)
             break;
     }
 
-    // TODO: Report errors here and below
-    if (!dir.cd(QStringLiteral("Contents")))
+    if (!dir.cd(QStringLiteral("Contents"))) {
+        qWarning("Cannot change directory into 'Contents' for docset at '%s'", qPrintable(m_path));
         return;
+    }
 
     // TODO: 'info.plist' is invalid according to Apple, and must always be 'Info.plist'
     // https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPRuntimeConfig
@@ -76,11 +77,15 @@ Docset::Docset(QString path)
         plist.read(dir.filePath(QStringLiteral("Info.plist")));
     else if (dir.exists(QStringLiteral("info.plist")))
         plist.read(dir.filePath(QStringLiteral("info.plist")));
-    else
+    else {
+        qWarning("Cannot access file 'Info.plist' or 'info.plist' for docset at '%s'", qPrintable(m_path));
         return;
+    }
 
-    if (plist.hasError())
+    if (plist.hasError()) {
+        qWarning("Error parsing 'Info.plist' for docset at '%s'", qPrintable(m_path));
         return;
+    }
 
     if (m_name.isEmpty()) {
         // Fallback if meta.json is absent
@@ -104,8 +109,15 @@ Docset::Docset(QString path)
         m_name = m_name + QLatin1String("cheats");
     }
 
-    if (!dir.cd(QStringLiteral("Resources")) || !dir.exists(QStringLiteral("docSet.dsidx")))
+    if (!dir.cd(QStringLiteral("Resources"))) {
+        qWarning("Cannot change directory into 'Resources' for docset %s", qPrintable(m_name));
         return;
+    }
+
+    if (!dir.exists(QStringLiteral("docSet.dsidx"))) {
+        qWarning("Cannot access file 'docSet.dsidx' for docset %s", qPrintable(m_name));
+        return;
+    }
 
     m_db = new Util::SQLiteDatabase(dir.filePath(QStringLiteral("docSet.dsidx")));
 
@@ -127,6 +139,7 @@ Docset::Docset(QString path)
     }
 
     if (!dir.cd(QStringLiteral("Documents"))) {
+        qWarning("Cannot change directory into 'Documents' for docset %s", qPrintable(m_name));
         m_type = Type::Invalid;
         return;
     }


### PR DESCRIPTION
While authoring a new Zeal docset recently I configured the docset wrong and had to debug the issue, but the only error message Zeal would give me was:

```
Could not load docset from 'PATH'. Reinstall the docset.
```

I went through the code trying to find the root cause of this error and discovered a TODO in `src/libs/registry/docset.cpp` suggesting that the errors leading to that message should be reported in more detail. I decided to try fix this myself, which is what this pull request does, adding new error messages for missing directories or files and for a malformed `Info.plist`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when opening or indexing docsets: explicit warning messages replace silent failures and abort processing on critical filesystem errors.
  * Prevents hidden failures by returning early when required metadata, resources, or index files are missing or unreadable.
  * Warning messages now clearly indicate whether the issue relates to the original path or the specific docset to aid diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->