### PR TITLE
ci(github): update AppImage build tools

### DIFF
--- a/.github/workflows/appimage/Dockerfile
+++ b/.github/workflows/appimage/Dockerfile
@@ -1,24 +1,25 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
+
+# Force older pipx to use global location.
+ENV PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man
 
 RUN apt-get update -q -y \
-   # Install appimage-builder and appimagetool dependencies.
+    # Install appimage-builder and appimagetool dependencies.
     && DEBIAN_FRONTEND="noninteractive" apt-get install -q -y --no-install-recommends \
-       appstream curl desktop-file-utils fakeroot file git gnupg patchelf squashfs-tools zsync  \
-       python3-pip python3-setuptools python3-wheel \
-    && \
+       appstream curl desktop-file-utils fakeroot file git gnupg patchelf pipx squashfs-tools zsync \
     # Install appimagetool, it has to be extracted because FUSE doesn't work in containers without extra fiddling.
-    cd /tmp && \
-    curl -sLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage && \
-    chmod +x appimagetool-x86_64.AppImage && \
-    ./appimagetool-x86_64.AppImage --appimage-extract && \
-    mv squashfs-root/ /opt/appimagetool.AppDir && \
-    ln -s /opt/appimagetool.AppDir/AppRun /usr/local/bin/appimagetool && \
-    rm appimagetool-x86_64.AppImage && \
-    cd - && \
+    && cd /tmp \
+    && curl -sLO https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage \
+    && chmod +x appimagetool-x86_64.AppImage \
+    && ./appimagetool-x86_64.AppImage --appimage-extract \
+    && mv squashfs-root/ /opt/appimagetool.AppDir \
+    && ln -s /opt/appimagetool.AppDir/AppRun /usr/local/bin/appimagetool \
+    && rm appimagetool-x86_64.AppImage \
+    && cd - \
     # Install appimage-builder.
-    pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git@669213cb730e007d5b316ed19b39691fbdcd41c4 && \
-    apt-get clean && \
-        rm -rf /var/lib/apt/lists/*
+    && pipx install git+https://github.com/AppImageCrafters/appimage-builder.git@d96cf01e131e01b9f9e713db8efa7d20c57f6a09 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set entrypoint.
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -202,17 +202,17 @@ jobs:
         with:
           recipe: pkg/appimage/appimage-amd64.yaml
           apt_dependencies: >-
+            appstream
             build-essential
             cmake extra-cmake-modules
-            libappindicator-dev
             libarchive-dev
+            libayatana-appindicator3-dev
             libqt5x11extras5-dev
             libsqlite3-dev
             libxcb-keysyms1-dev
             ninja-build
             qtbase5-dev
             qtwebengine5-dev
-            appstream
 
       - name: Upload AppImage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,9 +113,10 @@ jobs:
         with:
           recipe: pkg/appimage/appimage-amd64.yaml
           apt_dependencies: >-
+            appstream
             build-essential
             cmake extra-cmake-modules
-            libappindicator-dev
+            libayatana-appindicator3-dev
             libarchive-dev
             libqt5x11extras5-dev
             libsqlite3-dev

--- a/pkg/appimage/appimage-amd64.yaml
+++ b/pkg/appimage/appimage-amd64.yaml
@@ -23,10 +23,11 @@ AppDir:
   apt:
     arch: amd64
     sources:
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble main restricted universe multiverse
         key_url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920d1991bc93c
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-updates main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://security.ubuntu.com/ubuntu/ noble-security main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-backports main restricted universe multiverse
     include:
       # Required Qt packages.
       - libqt5concurrent5
@@ -73,5 +74,6 @@ AppDir:
 
 AppImage:
   arch: x86_64
-  update-information: gh-releases-zsync|zealdocs|zeal|latest|zeal-*x86_64.AppImage.zsync
+  comp: xz
   sign-key: None
+  update-information: gh-releases-zsync|zealdocs|zeal|latest|zeal-*x86_64.AppImage.zsync


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated AppImage build environment to Ubuntu 24.04 (Noble) and added Noble security sources.
  - Switched Python tooling to pipx and updated AppImage tooling installation and retrieval.
  - Replaced libappindicator-dev with libayatana-appindicator3-dev for newer runners.

- Performance
  - Enabled xz compression for AppImage to reduce package size and downloads.

- Release
  - CI workflows now build AppImage on ubuntu-24.04, aligning builds with updated base and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->