### PR TITLE
feat(ui): allow hiding menu bar

### DIFF
--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -23,6 +23,7 @@
 
 namespace {
 // Configuration file groups
+constexpr char GroupUI[] = "ui";
 constexpr char GroupContent[] = "content";
 constexpr char GroupDocsets[] = "docsets";
 constexpr char GroupGlobalShortcuts[] = "global_shortcuts";
@@ -94,6 +95,10 @@ void Settings::load()
     showSystrayIcon = settings->value(QStringLiteral("show_systray_icon"), true).toBool();
     minimizeToSystray = settings->value(QStringLiteral("minimize_to_systray"), false).toBool();
     hideOnClose = settings->value(QStringLiteral("hide_on_close"), false).toBool();
+
+    settings->beginGroup(GroupUI);
+    hideMenuBar = settings->value(QStringLiteral("hide_menu_bar"), false).toBool();
+    settings->endGroup();
 
     settings->beginGroup(GroupGlobalShortcuts);
     showShortcut = settings->value(QStringLiteral("show")).value<QKeySequence>();
@@ -226,6 +231,10 @@ void Settings::save()
     settings->setValue(QStringLiteral("show_systray_icon"), showSystrayIcon);
     settings->setValue(QStringLiteral("minimize_to_systray"), minimizeToSystray);
     settings->setValue(QStringLiteral("hide_on_close"), hideOnClose);
+
+    settings->beginGroup(GroupUI);
+    settings->setValue(QStringLiteral("hide_menu_bar"), hideMenuBar);
+    settings->endGroup();
 
     settings->beginGroup(GroupGlobalShortcuts);
     settings->setValue(QStringLiteral("show"), showShortcut);

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -25,6 +25,7 @@ public:
     // Startup
     bool startMinimized;
     bool checkForUpdate;
+    bool hideMenuBar;
     // TODO: bool restoreLastState;
 
     // System Tray

--- a/src/libs/ui/mainwindow.h
+++ b/src/libs/ui/mainwindow.h
@@ -96,6 +96,9 @@ private:
     QAction *m_quitAction = nullptr;
     QAction *m_showDocsetManagerAction = nullptr;
     QAction *m_showPreferencesAction = nullptr;
+#ifndef Q_OS_MACOS
+    QAction *m_showMenuBarAction = nullptr;
+#endif
 
     friend class SidebarViewProvider;
 


### PR DESCRIPTION
Fixes #1202.
Fixes #1251.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to hide/show the menu bar on non-macOS platforms, persisted across sessions.
  * View > Toolbars > Menu Bar toggle (checkable) with Ctrl+M shortcut.
  * Press F10 to reveal and focus the menu bar and activate the first item.
  * Menu bar auto-hides on focus loss or when Esc is pressed (non-macOS).
  * macOS behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->