### PR TITLE
ci(github): add custom vcpkg cache

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -127,7 +127,10 @@ jobs:
             publishArtifacts: true
 
     env:
-      VCPKG_DEFAULT_TRIPLET: x64-windows-release
+      _vcpkg_binary_cache: ${{ github.workspace }}/.vcpkg-cache
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite
+      VCPKG_BUILD_TYPE: release
+      VCPKG_DEFAULT_TRIPLET: x64-windows
 
     steps:
       - name: Checkout
@@ -135,10 +138,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Workaround for https://github.com/lukka/run-vcpkg/issues/251.
+      - name: Restore vcpkg Cache
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env._vcpkg_binary_cache }}
+          key: vcpkg-${{ matrix.config.os }}-${{ matrix.config.buildPreset }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: vcpkg-${{ matrix.config.os }}-${{ matrix.config.buildPreset }}-
+
       - name: Prepare vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgDirectory: ${{ github.workspace }}/vcpkg
+          vcpkgDirectory: ${{ github.workspace }}/.vcpkg
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
@@ -154,6 +166,13 @@ jobs:
         with:
           configurePreset: ${{ matrix.config.configurePreset }}
           buildPreset: ${{ matrix.config.buildPreset }}
+
+      - name: Save vcpkg Cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env._vcpkg_binary_cache }}
+          key: vcpkg-${{ matrix.config.os }}-${{ matrix.config.buildPreset }}-${{ hashFiles('vcpkg.json') }}
 
       - name: Retrieve Application Version
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,10 @@ jobs:
             buildPreset: ninja-multi-vcpkg-portable-release
 
     env:
+      _vcpkg_binary_cache: ${{ github.workspace }}/.vcpkg-cache
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite
+      VCPKG_BUILD_TYPE: release
+      VCPKG_DEFAULT_TRIPLET: x64-windows
       ZEAL_RELEASE_BUILD: ON
 
     steps:
@@ -51,13 +55,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Workaround for https://github.com/lukka/run-vcpkg/issues/251.
+      - name: Restore vcpkg Cache
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env._vcpkg_binary_cache }}
+          key: vcpkg-${{ matrix.config.os }}-${{ matrix.config.buildPreset }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: vcpkg-${{ matrix.config.os }}-${{ matrix.config.buildPreset }}-
+
       - name: Prepare vcpkg
         uses: lukka/run-vcpkg@v11
-        env:
-          VCPKG_BUILD_TYPE: release
-          VCPKG_DEFAULT_TRIPLET: x64-windows-release
         with:
-          vcpkgDirectory: ${{ github.workspace }}/vcpkg
+          vcpkgDirectory: ${{ github.workspace }}/.vcpkg
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
@@ -73,6 +83,13 @@ jobs:
         with:
           configurePreset: ${{ matrix.config.configurePreset }}
           buildPreset: ${{ matrix.config.buildPreset }}
+
+      - name: Save vcpkg Cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env._vcpkg_binary_cache }}
+          key: vcpkg-${{ matrix.config.os }}-${{ matrix.config.buildPreset }}-${{ hashFiles('vcpkg.json') }}
 
       - name: Retrieve Application Version
         run: |


### PR DESCRIPTION
Workaround for https://github.com/lukka/run-vcpkg/issues/251.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added vcpkg binary caching to Windows build and release workflows to speed up builds.
  * Introduced job-level vcpkg environment configuration for consistent release-oriented Windows builds.
  * Added cache restore/save steps with fallback keys to improve CI reliability.
  * Included a temporary workaround for a known vcpkg/tooling issue to stabilize Windows runs.
  * Linux/AppImage workflows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->