### PR TITLE
build(appimage): revert to 22.04

### DIFF
--- a/.github/workflows/appimage/Dockerfile
+++ b/.github/workflows/appimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:jammy
 
 # Force older pipx to use global location.
 ENV PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man

--- a/pkg/appimage/appimage-amd64.yaml
+++ b/pkg/appimage/appimage-amd64.yaml
@@ -23,11 +23,11 @@ AppDir:
   apt:
     arch: amd64
     sources:
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
         key_url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920d1991bc93c
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-updates main restricted universe multiverse
-      - sourceline: deb [arch=amd64] http://security.ubuntu.com/ubuntu/ noble-security main restricted universe multiverse
-      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-backports main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
+      - sourceline: deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
     include:
       # Required Qt packages.
       - libqt5concurrent5


### PR DESCRIPTION
Address intermittent build failure due to gcc-14. It can be figured out later. Jammy is supported for another year and more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated AppImage build environment to Ubuntu 22.04 (Jammy) for AMD64.
  - Aligned package repositories to Jammy across the build and AppImage configuration.
  - No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->