### PR TITLE
refactor: use categorized logging everywhere

### DIFF
--- a/src/libs/core/applicationsingleton.cpp
+++ b/src/libs/core/applicationsingleton.cpp
@@ -25,7 +25,11 @@ ApplicationSingleton::ApplicationSingleton(QObject *parent)
     : QObject(parent)
 {
     if (QCoreApplication::instance() == nullptr) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        qCFatal(log, "QCoreApplication (or derived type) must be created before ApplicationSingleton.");
+#else
         qFatal("QCoreApplication (or derived type) must be created before ApplicationSingleton.");
+#endif
     }
 
     m_id = computeId();

--- a/src/libs/core/extractor.cpp
+++ b/src/libs/core/extractor.cpp
@@ -4,6 +4,7 @@
 #include "extractor.h"
 
 #include <QDir>
+#include <QLoggingCategory>
 
 #include <archive.h>
 #include <archive_entry.h>
@@ -11,6 +12,8 @@
 #include <sys/stat.h>
 
 using namespace Zeal::Core;
+
+static Q_LOGGING_CATEGORY(log, "zeal.core.extractor")
 
 Extractor::Extractor(QObject *parent)
     : QObject(parent)
@@ -62,13 +65,13 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
         }
 
         if (filetype != S_IFREG) {
-            qWarning("Unsupported filetype %d for %s!", filetype, qPrintable(pathname));
+            qCWarning(log, "Unsupported filetype %d at '%s'.", filetype, qPrintable(pathname));
             continue;
         }
 
         QScopedPointer<QFile> file(new QFile(filePath));
         if (!file->open(QIODevice::WriteOnly)) {
-            qWarning("Cannot open file for writing: %s", qPrintable(pathname));
+            qCWarning(log, "Cannot open file for writing at '%s'.", qPrintable(pathname));
             continue;
         }
 
@@ -82,7 +85,7 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
                     break;
                 }
 
-                qWarning("Cannot read from archive: %s", archive_error_string(info.archiveHandle));
+                qCWarning(log, "Cannot read from archive: %s.", archive_error_string(info.archiveHandle));
                 emit error(sourceFile,
                            QString::fromLocal8Bit(archive_error_string(info.archiveHandle)));
                 return;

--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -13,6 +13,7 @@
 #include <core/httpserver.h>
 
 #include <QDir>
+#include <QLoggingCategory>
 #include <QThread>
 
 #include <QtConcurrent>
@@ -21,6 +22,8 @@
 #include <future>
 
 using namespace Zeal::Registry;
+
+static Q_LOGGING_CATEGORY(log, "zeal.registry.docsetregistry")
 
 void MergeQueryResults(QList<SearchResult> &finalResult, const QList<SearchResult> &partial)
 {
@@ -112,8 +115,8 @@ void DocsetRegistry::loadDocset(const QString &path)
     Docset *docset = f.get();
     // TODO: Emit error
     if (!docset->isValid()) {
-        qWarning("Could not load docset from '%s'. Reinstall the docset.",
-                 qPrintable(docset->path()));
+        qCWarning(log, "Could not load docset '%s' from '%s'. Reinstall the docset.",
+                  qPrintable(docset->name()), qPrintable(docset->path()));
         delete docset;
         return;
     }
@@ -128,8 +131,8 @@ void DocsetRegistry::loadDocset(const QString &path)
     // Setup HTTP mount.
     QUrl url = Core::Application::instance()->httpServer()->mount(name, docset->documentPath());
     if (url.isEmpty()) {
-        qWarning("Could not enable docset from '%s'. Reinstall the docset.",
-                 qPrintable(docset->path()));
+        qCWarning(log, "Could not enable docset '%s' from '%s'. Reinstall the docset.",
+                  qPrintable(docset->name()), qPrintable(docset->path()));
         delete docset;
         return;
     }

--- a/src/libs/sidebar/proxyview.cpp
+++ b/src/libs/sidebar/proxyview.cpp
@@ -7,12 +7,15 @@
 
 #include <ui/widgets/layouthelper.h>
 
+#include <QLoggingCategory>
 #include <QVBoxLayout>
 
 #include <utility>
 
 using namespace Zeal;
 using namespace Zeal::Sidebar;
+
+static Q_LOGGING_CATEGORY(log, "zeal.sidebar.proxyview")
 
 ProxyView::ProxyView(ViewProvider *provider, QString id, QWidget *parent)
     : View(parent)
@@ -24,7 +27,7 @@ ProxyView::ProxyView(ViewProvider *provider, QString id, QWidget *parent)
     connect(m_viewProvider, &ViewProvider::viewChanged, this, [this]() {
         auto view = m_viewProvider->view(m_viewId);
         if (view == nullptr) {
-            qWarning("ViewProvider returned invalid view!");
+            qCWarning(log, "ViewProvider returned invalid view for id '%s'.", qPrintable(m_viewId));
             return;
         }
 


### PR DESCRIPTION
Use `QLoggingCategory` everywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More informative, context-rich logging across core, registry, sidebar, extractor, and UI areas.

- Bug Fixes
  - Improved reporting for keyboard shortcut registration/unregistration and invalid view handling; clearer messages when resources or docsets fail to load.

- Refactor
  - Standardized categorized logging throughout the app for consistent, filterable diagnostics and improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->