### PR TITLE
feat(ui,util): show "humanized" docset list refreshed time

### DIFF
--- a/src/libs/ui/CMakeLists.txt
+++ b/src/libs/ui/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(Ui STATIC
     ${Ui_FORMS} # For Qt Creator.
 )
 
-target_link_libraries(Ui Browser Sidebar QxtGlobalShortcut Widgets Registry)
+target_link_libraries(Ui Browser Sidebar QxtGlobalShortcut Widgets Registry Util)
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS WebEngineWidgets REQUIRED)
 target_link_libraries(Ui Qt${QT_VERSION_MAJOR}::WebEngineWidgets)

--- a/src/libs/ui/docsetsdialog.h
+++ b/src/libs/ui/docsetsdialog.h
@@ -12,6 +12,7 @@
 #include <QHash>
 #include <QMap>
 
+class QDateTime;
 class QListWidgetItem;
 class QNetworkReply;
 class QTemporaryFile;
@@ -94,6 +95,7 @@ private:
     void loadUserFeedList();
     void downloadDocsetList();
     void processDocsetList(const QJsonArray &list);
+    void updateDocsetListDownloadTimeLabel(const QDateTime &modifiedTime);
 
     void downloadDashDocset(const QModelIndex &index);
     void removeDocset(const QString &name);

--- a/src/libs/ui/docsetsdialog.ui
+++ b/src/libs/ui/docsetsdialog.ui
@@ -133,13 +133,6 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Last updated:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QLabel" name="lastUpdatedLabel">
            <property name="text">
             <string/>

--- a/src/libs/util/CMakeLists.txt
+++ b/src/libs/util/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(CMAKE_AUTOMOC OFF)
 
 add_library(Util STATIC
+    humanizer.cpp
     plist.cpp
     sqlitedatabase.cpp
 

--- a/src/libs/util/humanizer.cpp
+++ b/src/libs/util/humanizer.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "humanizer.h"
+
+#include <QDateTime>
+
+#include <cmath>
+
+using namespace Zeal::Util;
+
+namespace {
+// Time thresholds in seconds.
+constexpr double Minute = 60.0;
+constexpr double Hour = 3600.0;
+constexpr double Day = 86400.0;
+// constexpr double Week = 604800.0; // Not used at the moment.
+constexpr double Month = 2629746.0; // Average month (30.44 days)
+constexpr double Year = 31556952.0; // Average year (365.25 days)
+
+QString humanizeDuration(double seconds)
+{
+    if (seconds < 45) {
+        return Humanizer::tr("a few seconds");
+    } else if (seconds < 90) {
+        return Humanizer::tr("a minute");
+    } else if (seconds < 45 * Minute) {
+        const int minutes = static_cast<int>(std::round(seconds / Minute));
+        // return Humanizer::tr("%n minute(s)", nullptr, minutes);
+        return Humanizer::tr("%1 minutes").arg(minutes);
+    } else if (seconds < 90 * Minute) {
+        return Humanizer::tr("an hour");
+    } else if (seconds < 22 * Hour) {
+        const int hours = static_cast<int>(std::round(seconds / Hour));
+        // return Humanizer::tr("%n hour(s)", nullptr, hours);
+        return Humanizer::tr("%1 hours").arg(hours);
+    } else if (seconds < 36 * Hour) {
+        return Humanizer::tr("a day");
+    } else if (seconds < 25 * Day) {
+        const int days = static_cast<int>(std::round(seconds / Day));
+        // return Humanizer::tr("%n day(s)", nullptr, days);
+        return Humanizer::tr("%1 days").arg(days);
+    } else if (seconds < 45 * Day) {
+        return Humanizer::tr("a month");
+    } else if (seconds < 320 * Day) {
+        const int months = static_cast<int>(std::round(seconds / Month));
+        // return Humanizer::tr("%n month(s)", nullptr, months);
+        return Humanizer::tr("%1 months").arg(months);
+    } else if (seconds < 548 * Day) {
+        return Humanizer::tr("a year");
+    } else {
+        const int years = static_cast<int>(std::round(seconds / Year));
+        // return Humanizer::tr("%n year(s)", nullptr, years);
+        return Humanizer::tr("%1 years").arg(years);
+    }
+}
+} // namespace
+
+QString Humanizer::fromNow(const QDateTime& dt)
+{
+    const double seconds = QDateTime::currentDateTime().secsTo(dt);
+    const QString humanizedDuration = humanizeDuration(std::abs(seconds));
+
+    return  (seconds > 0 ? tr("%1 from now") : tr("%1 ago")).arg(humanizedDuration);
+}

--- a/src/libs/util/humanizer.h
+++ b/src/libs/util/humanizer.h
@@ -1,0 +1,28 @@
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ZEAL_UTIL_HUMANIZER_H
+#define ZEAL_UTIL_HUMANIZER_H
+
+#include <QCoreApplication>
+#include <QString>
+
+class QDateTime;
+
+namespace Zeal {
+namespace Util {
+
+class Humanizer
+{
+    Q_DECLARE_TR_FUNCTIONS(Humanizer)
+    Q_DISABLE_COPY_MOVE(Humanizer)
+    Humanizer() = delete;
+    ~Humanizer() = delete;
+public:
+    static QString fromNow(const QDateTime& dt);
+};
+
+} // namespace Util
+} // namespace Zeal
+
+#endif // ZEAL_UTIL_HUMANIZER_H


### PR DESCRIPTION
Related to #1002 and #1189.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - “Last updated” now shows a human-friendly relative time (e.g., “5 hours ago”).

- **UI**
  - Hover the label to see the exact timestamp in your system’s date-time format.
  - Removed the redundant static “Last updated:” prefix for a cleaner look.

- **Chores**
  - Added a shared humanizer utility and updated build linkage so it’s available across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->