### PR TITLE
ci(github): add arm64 ubuntu builds

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -52,6 +52,26 @@ jobs:
               qt6-webengine-dev-tools
             configurePreset: ninja-multi-portable
             buildPreset: ninja-multi-portable-release
+          - name: Ubuntu 24.04 ARM64 / Qt 6
+            os: ubuntu-24.04-arm
+            qt_packages: >-
+              libgl1-mesa-dev
+              libqt6opengl6-dev
+              qt6-base-private-dev
+              qt6-webengine-dev
+              qt6-webengine-dev-tools
+            configurePreset: ninja-multi
+            buildPreset: ninja-multi-release
+          - name: Ubuntu 24.04 ARM64 / Qt 6 / Portable
+            os: ubuntu-24.04-arm
+            qt_packages: >-
+              libgl1-mesa-dev
+              libqt6opengl6-dev
+              qt6-base-private-dev
+              qt6-webengine-dev
+              qt6-webengine-dev-tools
+            configurePreset: ninja-multi-portable
+            buildPreset: ninja-multi-portable-release
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Ubuntu ARM builds fine, Windows build fails due to missing binaries for Qt WebEngine.

Related to #1411.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI build targets for Ubuntu 24.04 ARM64 with Qt 6, including a portable variant.
  * Builds now generate both standard and portable artifacts for this platform.
  * Improves platform coverage and release readiness for ARM64 on Ubuntu 24.04.
  * No changes to application functionality or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->