### PR TITLE
ci(github): build with Qt 6.9.3

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -130,7 +130,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.2"
+            qt_version: "6.9.3"
             configurePreset: ninja-multi-vcpkg
             buildPreset: ninja-multi-vcpkg-release
             publishArtifacts: true
@@ -141,7 +141,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.2"
+            qt_version: "6.9.3"
             configurePreset: ninja-multi-vcpkg-portable
             buildPreset: ninja-multi-vcpkg-portable-release
             publishArtifacts: true
@@ -179,7 +179,6 @@ jobs:
           modules: ${{ matrix.config.qt_modules }}
           version: ${{ matrix.config.qt_version }}
           cache: true
-          extra: --external 7z
 
       - name: Configure & Build
         uses: lukka/run-cmake@v10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.2"
+            qt_version: "6.9.3"
             configurePreset: ninja-multi-vcpkg
             buildPreset: ninja-multi-vcpkg-release
           - name: Windows Server 2022 / Qt 6 / Portable
@@ -38,7 +38,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.2"
+            qt_version: "6.9.3"
             configurePreset: ninja-multi-vcpkg-portable
             buildPreset: ninja-multi-vcpkg-portable-release
 
@@ -76,7 +76,6 @@ jobs:
           modules: ${{ matrix.config.qt_modules }}
           version: ${{ matrix.config.qt_version }}
           cache: true
-          extra: --external 7z
 
       - name: Configure & Build
         uses: lukka/run-cmake@v10


### PR DESCRIPTION
Update to the latest Qt 6.9 version.

Additionally, do not use external 7z with aqt due to https://github.com/miurahr/aqtinstall/issues/670. It's unclear why this started happening, but Qt installation works fine without it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Qt version to 6.9.3 for enhanced framework stability.
  * Optimized Windows build configuration for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->