### PR TITLE
[wip] Add Windows ARM64 Portable build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
             qt_version: "6.10.2"
             configurePreset: ninja-multi-vcpkg
             buildPreset: ninja-multi-vcpkg-release
+            defaultTriplet: x64-windows
           - name: Windows Server 2022 / Qt 6 / Portable
             os: windows-2022
             arch: win64_msvc2022_64
@@ -41,11 +42,23 @@ jobs:
             qt_version: "6.10.2"
             configurePreset: ninja-multi-vcpkg-portable
             buildPreset: ninja-multi-vcpkg-portable-release
+            defaultTriplet: x64-windows
+          - name: Windows 11 ARM64 / Qt 6 / Portable
+            os: windows-11-arm
+            arch: win64_msvc2022_arm64
+            qt_modules: >-
+              qtpositioning
+              qtwebchannel
+              qtwebengine
+            qt_version: "6.10.1"
+            configurePreset: ninja-multi-vcpkg-portable
+            buildPreset: ninja-multi-vcpkg-portable-release
+            defaultTriplet: arm64-windows
 
     env:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite
       VCPKG_BUILD_TYPE: release
-      VCPKG_DEFAULT_TRIPLET: x64-windows
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.config.defaultTriplet }}
       ZEAL_RELEASE_BUILD: ON
 
     steps:
@@ -102,8 +115,8 @@ jobs:
           # - Portable 7-Zip and ZIP packages.
           # - Non-portable MSI package.
           files: |
-            build/${{ matrix.config.configurePreset }}/zeal-${{ env.ZEAL_VERSION }}-portable-windows-x64.*
-            build/${{ matrix.config.configurePreset }}/zeal-${{ env.ZEAL_VERSION }}-windows-x64.msi*
+            build/${{ matrix.config.configurePreset }}/zeal-${{ env.ZEAL_VERSION }}-portable-windows-*.*
+            build/${{ matrix.config.configurePreset }}/zeal-${{ env.ZEAL_VERSION }}-windows-*.msi*
 
   build-appimage:
     name: AppImage


### PR DESCRIPTION
Addresses https://github.com/zealdocs/zeal/issues/1411

Unfortunately this can't be merged yet because Qt 6.10+ changed the paths of the qtwebengine package used by `jurplel/install-qt-action` due to https://github.com/jurplel/install-qt-action/issues/299 where the root cause is actually https://github.com/miurahr/aqtinstall/pull/952 (which is not yet released 😥)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Windows 11 ARM64 architecture builds.

* **Chores**
  * Updated Windows build configurations and artifact handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->