### PR TITLE
fix(registry): defer docset loading to improve startup performance

### DIFF
--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -66,12 +66,11 @@ void DocsetRegistry::setStoragePath(const QString &path)
         return;
     }
 
-   QString newPath = path;
-   QMetaObject::invokeMethod(this, [this, newPath](){
-    unloadAllDocsets();
-    addDocsetsFromFolder(newPath);
-    m_storagePath = newPath;
-   });
+    QMetaObject::invokeMethod(this, [this, path](){
+        unloadAllDocsets();
+        addDocsetsFromFolder(path);
+        m_storagePath = path;
+    });
 }
 
 bool DocsetRegistry::isFuzzySearchEnabled() const


### PR DESCRIPTION
Previously, all docsets were loaded during startup, which increased initialization time.  
With this change, docsets are loaded lazily, reducing startup latency and improving responsiveness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal formatting and structure updates for maintainability.

* **Performance**
  * Storage location changes and content reloads are now deferred and performed asynchronously, reducing blocking during updates and ensuring reloads finish before the new location takes effect for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->