### PR TITLE
ci(github): build with Qt 6.10.2

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -130,7 +130,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.3"
+            qt_version: "6.10.2"
             configurePreset: ninja-multi-vcpkg
             buildPreset: ninja-multi-vcpkg-release
             publishArtifacts: true
@@ -141,7 +141,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.3"
+            qt_version: "6.10.2"
             configurePreset: ninja-multi-vcpkg-portable
             buildPreset: ninja-multi-vcpkg-portable-release
             publishArtifacts: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.3"
+            qt_version: "6.10.2"
             configurePreset: ninja-multi-vcpkg
             buildPreset: ninja-multi-vcpkg-release
           - name: Windows Server 2022 / Qt 6 / Portable
@@ -38,7 +38,7 @@ jobs:
               qtpositioning
               qtwebchannel
               qtwebengine
-            qt_version: "6.9.3"
+            qt_version: "6.10.2"
             configurePreset: ninja-multi-vcpkg-portable
             buildPreset: ninja-multi-vcpkg-portable-release
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Qt toolchain from 6.9.3 to 6.10.2 for Windows Server 2022 build and release workflows to ensure compatibility with the latest Windows build environment and toolchain.
  * No functional or packaging changes; build logic and release steps remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->