### PR TITLE
build(app): add Windows 10/11 compatibility manifest

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -25,6 +25,7 @@ if(APPLE)
 elseif(WIN32)
     configure_file(versioninfo.rc.in ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc)
     list(APPEND App_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc)
+    list(APPEND App_RESOURCES zeal.manifest)
 else()
     set(App_RESOURCES) # Silence CMake warning.
 endif()

--- a/src/app/zeal.manifest
+++ b/src/app/zeal.manifest
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- This manifest is merged with the linker-generated one at build time.
+     See: https://cmake.org/cmake/help/latest/release/3.4.html
+     See: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
Fixes #1768.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows application manifest declaring Windows 10/11 compatibility and updated the Windows build configuration to include that manifest in generated application resources, improving runtime compatibility handling on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->