### PR TITLE
build(cmake): add clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,21 @@
+---
+HeaderFilterRegex: 'src/.*'
+Checks: >
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -fuchsia-*,
+  -google-*,
+  google-build-using-namespace,
+  -linuxkernel-*,
+  -llvmlibc-*,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-owning-memory,
+  -bugprone-easily-swappable-parameters,
+  -concurrency-mt-unsafe,
+  -cppcoreguidelines-prefer-member-initializer,
+  -modernize-use-trailing-return-type,
+  -readability-identifier-length,
+  -readability-function-cognitive-complexity,
+  -readability-magic-numbers,

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,17 @@ project(Zeal
     LANGUAGES CXX
 )
 
+option(ZEAL_USE_CLANG_TIDY "Enable clang-tidy static analysis" OFF)
+if(ZEAL_USE_CLANG_TIDY)
+    find_program(CLANG_TIDY_PROGRAM clang-tidy)
+    if(CLANG_TIDY_PROGRAM)
+        message(STATUS "Using clang-tidy: ${CLANG_TIDY_PROGRAM}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_PROGRAM}")
+    else()
+        message(FATAL_ERROR "ZEAL_USE_CLANG_TIDY is enabled but clang-tidy was not found.")
+    endif()
+endif()
+
 option(ZEAL_USE_COMPILER_CACHE "Enable compiler cache (sccache/ccache)" OFF)
 if(ZEAL_USE_COMPILER_CACHE)
     find_program(CCACHE_PROGRAM sccache ccache)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,6 +42,7 @@
       "name": "dev",
       "inherits": ["release"],
       "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "ZEAL_DEPLOY_QT_ON_BUILD": "ON",
         "ZEAL_USE_COMPILER_CACHE": "ON"
       },

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -28,8 +28,10 @@ SPDX-License-Identifier = "GPL-3.0-or-later"
 # MIT for auxiliary files.
 [[annotations]]
 path = [
-    ".clang-format",
     ".clang-format-ignore",
+    ".clang-format",
+    ".clang-tidy",
+    ".clangd",
     ".editorconfig",
     ".gitattributes",
     ".github/**/*",

--- a/tools/run-clang-format.ps1
+++ b/tools/run-clang-format.ps1
@@ -1,0 +1,51 @@
+#
+# run-clang-format.ps1 - Check or fix code formatting using clang-format
+#
+# SPDX-FileCopyrightText: Oleg Shparber, et al. <https://zealdocs.org>
+# SPDX-License-Identifier: MIT
+#
+# By default, runs in check mode (dry-run).
+# Use -Fix to apply changes.
+# Use -Staged to only process files staged for commit.
+# Use -Verbose to print each file being processed.
+#
+
+[CmdletBinding()]
+param(
+    [switch]$Fix,
+    [switch]$Staged
+)
+
+$srcDir = Join-Path -Path $PSScriptRoot -ChildPath "..\src"
+
+if ($Staged) {
+    $files = git diff --cached --name-only --diff-filter=ACMR -- "*.cpp" "*.h" |
+        ForEach-Object { Join-Path -Path $PSScriptRoot -ChildPath ".." -AdditionalChildPath $_ } |
+        Where-Object { Test-Path $_ }
+} else {
+    $files = Get-ChildItem -Recurse $srcDir -Include *.cpp, *.h |
+        Select-Object -ExpandProperty FullName
+}
+
+if (-not $files) {
+    Write-Information "No files to format."
+    exit 0
+}
+
+$formatArgs = @("--dry-run", "--Werror")
+if ($Fix) {
+    $formatArgs = @("-i")
+}
+
+$failed = $false
+foreach ($file in $files) {
+    Write-Verbose "Processing $file"
+    & clang-format @formatArgs $file
+    if ($LASTEXITCODE -ne 0) {
+        $failed = $true
+    }
+}
+
+if ($failed) {
+    exit 1
+}

--- a/tools/run-clang-tidy.ps1
+++ b/tools/run-clang-tidy.ps1
@@ -1,0 +1,69 @@
+#
+# run-clang-tidy.ps1 - Run clang-tidy static analysis on the codebase
+#
+# SPDX-FileCopyrightText: Oleg Shparber, et al. <https://zealdocs.org>
+# SPDX-License-Identifier: MIT
+#
+# By default, uses the project's .clang-tidy configuration.
+# Use -Check <name> to run a specific check (e.g., -Check readability-qualified-auto).
+# Use -Fix to apply suggested fixes.
+# Use -Staged to only process files staged for commit.
+# Use -Verbose to print each file being processed.
+#
+# Requires a compile_commands.json in the build directory (build/dev).
+#
+
+[CmdletBinding()]
+param(
+    [string]$Check,
+    [switch]$Fix,
+    [switch]$Staged
+)
+
+$buildDir = Join-Path -Path $PSScriptRoot -ChildPath "..\build\dev"
+
+if (-not (Test-Path "$buildDir/compile_commands.json")) {
+    Write-Error "compile_commands.json not found in $buildDir. Run 'cmake --preset dev' first."
+    exit 1
+}
+
+$buildDir = Resolve-Path $buildDir
+
+$tidyArgs = @("-p", $buildDir)
+if ($Check) {
+    $tidyArgs += "--config={Checks: '-*,$Check', HeaderFilterRegex: 'src/.*'}"
+}
+if ($Fix) {
+    $tidyArgs += "--fix"
+}
+
+$srcDir = Join-Path -Path $PSScriptRoot -ChildPath "..\src"
+
+if ($Staged) {
+    $files = git diff --cached --name-only --diff-filter=ACMR -- "*.cpp" |
+        ForEach-Object { Join-Path -Path $PSScriptRoot -ChildPath ".." -AdditionalChildPath $_ } |
+        Where-Object { Test-Path $_ }
+} else {
+    $excludeDir = Join-Path -Path $srcDir -ChildPath "contrib"
+    $files = Get-ChildItem -Recurse $srcDir -Include *.cpp |
+        Where-Object { -not $_.FullName.StartsWith($excludeDir) } |
+        Select-Object -ExpandProperty FullName
+}
+
+if (-not $files) {
+    Write-Information "No files to process."
+    exit 0
+}
+
+$failed = $false
+foreach ($file in $files) {
+    Write-Verbose "Processing $file"
+    & clang-tidy @tidyArgs $file
+    if ($LASTEXITCODE -ne 0) {
+        $failed = $true
+    }
+}
+
+if ($failed) {
+    exit 1
+}


### PR DESCRIPTION
Add helper scripts to run tidy/format on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added tooling and editor integration for clang-tidy and clangd using the development compilation database.
  * New build option to enable clang-tidy checks during configuration (disabled by default).
  * Development preset now exports compile commands for tooling.
  * Added scripts to run formatting and static analysis with options to auto-fix or limit to staged files.
  * Updated license metadata to include the new tooling/configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->