### PR TITLE
cmake(build): enable compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,13 @@ add_custom_target(zeal_version
     VERBATIM
 )
 
+# Enable all compiler warnings and treat them as errors.
+if(MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled a stricter, global compiler warning baseline across builds to surface more potential issues during compilation. This complements the existing conditional "warnings-as-errors" behavior for supported toolchain versions, improving code quality and helping catch potential problems earlier without changing existing build policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->