### PR TITLE
build(cmake): switch to C++20

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ---
 Language: Cpp
-Standard: c++17
+Standard: c++20
 
 # Indentation
 IndentWidth: 4

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find includes in corresponding build directories.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project-wide C++ language standard requirement from C++17 to C++20, affecting compilation settings.
  * Aligned code-formatting configuration to use the C++20 standard to ensure consistent formatting across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->