### PR TITLE
ci(github): fix clang-format check

### DIFF
--- a/.github/workflows/check-lint.yaml
+++ b/.github/workflows/check-lint.yaml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -33,9 +32,15 @@ jobs:
           version: '22'
           style: file
           tidy-checks: '-*'
-          format-review: true
+          file-annotations: true
           files-changed-only: false
           ignore-format: 'src/contrib'
+
+      - name: Fail on format issues
+        if: steps.linter.outputs.checks-failed > 0
+        run: |
+          echo "::error::${{ steps.linter.outputs.checks-failed }} formatting issue(s) found"
+          exit 1
 
   reuse:
     name: REUSE Compliance

--- a/src/libs/registry/searchresult.h
+++ b/src/libs/registry/searchresult.h
@@ -5,9 +5,9 @@
 #ifndef ZEAL_REGISTRY_SEARCHRESULT_H
 #define ZEAL_REGISTRY_SEARCHRESULT_H
 
+#include <QList>
 #include <QString>
 #include <QUrl>
-#include <QList>
 
 namespace Zeal::Registry {
 

--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
@@ -196,7 +196,10 @@ bool QxtGlobalShortcutPrivate::unregisterShortcut(quint32 nativeKey, quint32 nat
 
     QList<xcb_void_cookie_t> xcbCookies;
     for (quint32 maskMods : maskModifiers) {
-        xcbCookies << xcb_ungrab_key_checked(xcbConnection, nativeKey, QX11Info::appRootWindow(), nativeMods | maskMods);
+        xcbCookies << xcb_ungrab_key_checked(xcbConnection,
+                                             nativeKey,
+                                             QX11Info::appRootWindow(),
+                                             nativeMods | maskMods);
     }
 
     bool failed = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the linting workflow to surface formatting/lint problems more clearly via file annotations.
  * Added a step that fails the workflow when lint/format issues are detected to prevent overlooked problems.

* **Style**
  * Minor source formatting adjustments (include order and code indentation) with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->