### PR TITLE
refactor(ui): remove private slot decorations

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -31,14 +31,16 @@
 
 #include <memory>
 
-#ifdef Q_OS_WINDOWS
-extern Q_CORE_EXPORT int qt_ntfs_permission_lookup;
-#endif
-
 namespace Zeal::WidgetUi {
 
 namespace {
 Q_LOGGING_CATEGORY(log, "zeal.widgetui.docsetsdialog")
+
+enum DownloadType {
+    DownloadDashFeed,
+    DownloadDocset,
+    DownloadDocsetList
+};
 
 constexpr char ApiServerUrl[] = "https://api.zealdocs.org/v1";
 constexpr char RedirectServerUrl[] = "https://go.zealdocs.org/d/%1/%2/latest";
@@ -132,7 +134,7 @@ void DocsetsDialog::addDashFeed()
     }
 
     QNetworkReply *reply = download(QUrl(feedUrl));
-    reply->setProperty(DownloadTypeProperty, DownloadDashFeed);
+    reply->setProperty(DownloadTypeProperty, DownloadType::DownloadDashFeed);
 }
 
 void DocsetsDialog::updateSelectedDocsets()
@@ -274,7 +276,7 @@ void DocsetsDialog::downloadCompleted()
     }
 
     switch (reply->property(DownloadTypeProperty).toUInt()) {
-    case DownloadDocsetList: {
+    case DownloadType::DownloadDocsetList: {
         const QByteArray replyData = reply->readAll();
 
         QScopedPointer<QFile> file(new QFile(cacheLocation(DocsetListCacheFileName)));
@@ -309,7 +311,7 @@ void DocsetsDialog::downloadCompleted()
         break;
     }
 
-    case DownloadDashFeed: {
+    case DownloadType::DownloadDashFeed: {
         Registry::DocsetMetadata metadata = Registry::DocsetMetadata::fromDashFeed(reply->request().url(),
                                                                                    reply->readAll());
 
@@ -325,7 +327,7 @@ void DocsetsDialog::downloadCompleted()
             // since further downloads are only update checks
             QNetworkReply *mdReply = download(metadata.url());
             mdReply->setProperty(DocsetNameProperty, metadata.name());
-            mdReply->setProperty(DownloadTypeProperty, DownloadDocset);
+            mdReply->setProperty(DownloadTypeProperty, DownloadType::DownloadDocset);
         } else {
             // Check for feed update
             if (metadata.latestVersion() != docset->version() || metadata.revision() > docset->revision()) {
@@ -342,7 +344,7 @@ void DocsetsDialog::downloadCompleted()
         break;
     }
 
-    case DownloadDocset: {
+    case DownloadType::DownloadDocset: {
         const QString docsetName = reply->property(DocsetNameProperty).toString();
         const QString docsetDirectoryName = docsetName + QLatin1String(".docset");
 
@@ -395,7 +397,7 @@ void DocsetsDialog::downloadProgress(qint64 received, qint64 total)
         return;
     }
 
-    if (reply->property(DownloadTypeProperty).toInt() == DownloadDocset) {
+    if (reply->property(DownloadTypeProperty).toInt() == DownloadType::DownloadDocset) {
         const QString docsetName = reply->property(DocsetNameProperty).toString();
 
         QTemporaryFile *tmpFile = m_tmpFiles[docsetName];
@@ -708,7 +710,7 @@ void DocsetsDialog::cancelDownloads()
             listItem->setData(DocsetListItemDelegate::ShowProgressRole, false);
         }
 
-        if (reply->property(DownloadTypeProperty).toInt() == DownloadDocset) {
+        if (reply->property(DownloadTypeProperty).toInt() == DownloadType::DownloadDocset) {
             delete m_tmpFiles.take(reply->property(DocsetNameProperty).toString());
         }
 
@@ -724,7 +726,7 @@ void DocsetsDialog::loadUserFeedList()
     for (Registry::Docset *docset : docsets) {
         if (!docset->feedUrl().isEmpty()) {
             QNetworkReply *reply = download(QUrl(docset->feedUrl()));
-            reply->setProperty(DownloadTypeProperty, DownloadDashFeed);
+            reply->setProperty(DownloadTypeProperty, DownloadType::DownloadDashFeed);
         }
     }
 }
@@ -735,7 +737,7 @@ void DocsetsDialog::downloadDocsetList()
     m_availableDocsets.clear();
 
     QNetworkReply *reply = download(QUrl(ApiServerUrl + QLatin1String("/docsets")));
-    reply->setProperty(DownloadTypeProperty, DownloadDocsetList);
+    reply->setProperty(DownloadTypeProperty, DownloadType::DownloadDocsetList);
 }
 
 void DocsetsDialog::processDocsetList(const QJsonArray &list)
@@ -810,7 +812,7 @@ void DocsetsDialog::downloadDashDocset(const QModelIndex &index)
 
     QNetworkReply *reply = download(url);
     reply->setProperty(DocsetNameProperty, name);
-    reply->setProperty(DownloadTypeProperty, DownloadDocset);
+    reply->setProperty(DownloadTypeProperty, DownloadType::DownloadDocset);
     reply->setProperty(ListItemIndexProperty, ui->availableDocsetList->row(findDocsetListItem(name)));
 }
 

--- a/src/libs/ui/docsetsdialog.h
+++ b/src/libs/ui/docsetsdialog.h
@@ -42,7 +42,7 @@ public:
     explicit DocsetsDialog(Core::Application *app, QWidget *parent = nullptr);
     ~DocsetsDialog() override;
 
-private slots:
+private:
     void addDashFeed();
     void updateSelectedDocsets();
     void updateAllDocsets();
@@ -59,13 +59,6 @@ private slots:
     void extractionProgress(const QString &filePath, qint64 extracted, qint64 total);
 
     void loadDocsetList();
-
-private:
-    enum DownloadType {
-        DownloadDashFeed,
-        DownloadDocset,
-        DownloadDocsetList
-    };
 
     Ui::DocsetsDialog *ui = nullptr;
     Core::Application *m_application = nullptr;

--- a/src/libs/ui/mainwindow.h
+++ b/src/libs/ui/mainwindow.h
@@ -61,13 +61,12 @@ protected:
     bool eventFilter(QObject *object, QEvent *event) override;
     void keyPressEvent(QKeyEvent *keyEvent) override;
 
-private slots:
+private:
     void applySettings();
     void closeTab(int index = -1);
     void moveTab(int from, int to);
     void duplicateTab(int index);
 
-private:
     void setupMainMenu();
     void setupShortcuts();
     void setupTabBar();

--- a/src/libs/ui/searchsidebar.cpp
+++ b/src/libs/ui/searchsidebar.cpp
@@ -311,62 +311,6 @@ void SearchSidebar::search(const Registry::SearchQuery &query)
     m_searchEdit->setText(query.toString());
 }
 
-void SearchSidebar::navigateToIndex(const QModelIndex &index)
-{
-    // When triggered by click, cancel delayed navigation request caused by the selection change.
-    if (m_delayedNavigationTimer->isActive() && m_delayedNavigationTimer->property("index").toModelIndex() == index) {
-        m_delayedNavigationTimer->stop();
-    }
-
-    const QVariant url = index.data(Registry::ItemDataRole::UrlRole);
-    if (url.isNull()) {
-        return;
-    }
-
-    emit navigationRequested(url.toUrl());
-}
-
-void SearchSidebar::navigateToIndexAndActivate(const QModelIndex &index)
-{
-    const QVariant url = index.data(Registry::ItemDataRole::UrlRole);
-    if (url.isNull()) {
-        return;
-    }
-
-    emit navigationRequested(url.toUrl());
-    emit activated();
-}
-
-void SearchSidebar::navigateToSelectionWithDelay(const QItemSelection &selection)
-{
-    if (selection.isEmpty()) {
-        return;
-    }
-
-    m_delayedNavigationTimer->setProperty("index", selection.indexes().first());
-    m_delayedNavigationTimer->start();
-}
-
-void SearchSidebar::setupSearchBoxCompletions()
-{
-    QStringList completions;
-    const auto docsets = Core::Application::instance()->docsetRegistry()->docsets();
-    for (const Registry::Docset *docset : docsets) {
-        const QStringList keywords = docset->keywords();
-        if (keywords.isEmpty()) {
-            continue;
-        }
-
-        completions << keywords.constFirst() + QLatin1Char(':');
-    }
-
-    if (completions.isEmpty()) {
-        return;
-    }
-
-    m_searchEdit->setCompletions(completions);
-}
-
 bool SearchSidebar::eventFilter(QObject *object, QEvent *event)
 {
     if (object == m_treeView->viewport() && event->type() == QEvent::MouseButtonPress) {
@@ -462,6 +406,62 @@ void SearchSidebar::showEvent(QShowEvent *event)
         m_searchEdit->setFocus();
         m_pendingSearchEditFocus = false;
     }
+}
+
+void SearchSidebar::navigateToIndex(const QModelIndex &index)
+{
+    // When triggered by click, cancel delayed navigation request caused by the selection change.
+    if (m_delayedNavigationTimer->isActive() && m_delayedNavigationTimer->property("index").toModelIndex() == index) {
+        m_delayedNavigationTimer->stop();
+    }
+
+    const QVariant url = index.data(Registry::ItemDataRole::UrlRole);
+    if (url.isNull()) {
+        return;
+    }
+
+    emit navigationRequested(url.toUrl());
+}
+
+void SearchSidebar::navigateToIndexAndActivate(const QModelIndex &index)
+{
+    const QVariant url = index.data(Registry::ItemDataRole::UrlRole);
+    if (url.isNull()) {
+        return;
+    }
+
+    emit navigationRequested(url.toUrl());
+    emit activated();
+}
+
+void SearchSidebar::navigateToSelectionWithDelay(const QItemSelection &selection)
+{
+    if (selection.isEmpty()) {
+        return;
+    }
+
+    m_delayedNavigationTimer->setProperty("index", selection.indexes().first());
+    m_delayedNavigationTimer->start();
+}
+
+void SearchSidebar::setupSearchBoxCompletions()
+{
+    QStringList completions;
+    const auto docsets = Core::Application::instance()->docsetRegistry()->docsets();
+    for (const Registry::Docset *docset : docsets) {
+        const QStringList keywords = docset->keywords();
+        if (keywords.isEmpty()) {
+            continue;
+        }
+
+        completions << keywords.constFirst() + QLatin1Char(':');
+    }
+
+    if (completions.isEmpty()) {
+        return;
+    }
+
+    m_searchEdit->setCompletions(completions);
 }
 
 } // namespace Zeal::WidgetUi

--- a/src/libs/ui/searchsidebar.h
+++ b/src/libs/ui/searchsidebar.h
@@ -47,12 +47,6 @@ public slots:
     void focusSearchEdit(bool clear = false);
     void search(const Registry::SearchQuery &query);
 
-private slots:
-    void navigateToIndex(const QModelIndex &index);
-    void navigateToIndexAndActivate(const QModelIndex &index);
-    void navigateToSelectionWithDelay(const QItemSelection &selection);
-    void setupSearchBoxCompletions();
-
 protected:
     bool eventFilter(QObject *object, QEvent *event) override;
     void showEvent(QShowEvent *event) override;
@@ -60,6 +54,11 @@ protected:
 private:
     explicit SearchSidebar(const SearchSidebar *other, QWidget *parent = nullptr);
     void setTreeViewModel(QAbstractItemModel *model, bool isRootDecorated);
+
+    void navigateToIndex(const QModelIndex &index);
+    void navigateToIndexAndActivate(const QModelIndex &index);
+    void navigateToSelectionWithDelay(const QItemSelection &selection);
+    void setupSearchBoxCompletions();
 
     SearchEdit *m_searchEdit = nullptr;
     bool m_pendingSearchEditFocus = false;

--- a/src/libs/ui/widgets/searchedit.h
+++ b/src/libs/ui/widgets/searchedit.h
@@ -27,10 +27,9 @@ protected:
     bool event(QEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
 
-private slots:
+private:
     void showCompletions(const QString &text);
 
-private:
     QString currentCompletion(const QString &text) const;
     int queryStart() const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and simplified internal download handling and reply state management for docset/feed operations.
  * Converted numerous UI helper methods from Qt slot declarations to ordinary private methods and reorganized related implementations.

---

Note: No user-facing features or behavioral changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->