### PR TITLE
refactor(ui): drop Xlib from global shortcut

### DIFF
--- a/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
+++ b/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
@@ -7,8 +7,14 @@ if(APPLE)
         qxtglobalshortcut_mac.cpp
     )
 elseif(UNIX)
-    find_package(X11)
-    if(X11_FOUND)
+    # ECM provides FindXCB.cmake; neither CMake nor libxcb ships one.
+    find_package(ECM QUIET NO_MODULE)
+    if(ECM_FOUND)
+        list(APPEND CMAKE_MODULE_PATH ${ECM_FIND_MODULE_DIR})
+        find_package(XCB COMPONENTS XCB KEYSYMS QUIET)
+    endif()
+
+    if(XCB_FOUND)
         list(APPEND QxtGlobalShortcut_SOURCES
             qxtglobalshortcut_x11.cpp
         )
@@ -35,17 +41,9 @@ target_link_libraries(QxtGlobalShortcut PRIVATE Qt6::Gui)
 if(APPLE)
     find_library(CARBON_LIBRARY Carbon)
     target_link_libraries(QxtGlobalShortcut PRIVATE ${CARBON_LIBRARY})
-elseif(UNIX AND X11_FOUND)
-    target_link_libraries(QxtGlobalShortcut PRIVATE ${X11_LIBRARIES})
-
+elseif(UNIX AND XCB_FOUND)
     if(Qt6Core_VERSION VERSION_GREATER_EQUAL 6.10)
         find_package(Qt6 COMPONENTS GuiPrivate REQUIRED)
     endif()
-    target_link_libraries(QxtGlobalShortcut PRIVATE Qt6::GuiPrivate)
-
-    find_package(ECM REQUIRED NO_MODULE)
-    set(CMAKE_MODULE_PATH ${ECM_FIND_MODULE_DIR})
-
-    find_package(XCB COMPONENTS XCB KEYSYMS REQUIRED)
-    target_link_libraries(QxtGlobalShortcut PRIVATE XCB::XCB XCB::KEYSYMS)
+    target_link_libraries(QxtGlobalShortcut PRIVATE Qt6::GuiPrivate XCB::XCB XCB::KEYSYMS)
 endif()

--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
@@ -40,10 +40,6 @@
 #include <QtGui/private/qtx11extras_p.h>
 #include <QtGui/private/qxkbcommon_p.h>
 
-// X11 headers define KeyPress/KeyRelease as macros that conflict with Qt enums.
-#include <X11/Xlib.h>
-#undef KeyPress
-#undef KeyRelease
 #include <xcb/xcb.h>
 #include <xcb/xcb_keysyms.h>
 
@@ -121,7 +117,7 @@ quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key, quint32 &extraNativ
     QKeyEvent dummy(QEvent::KeyPress, key, Qt::NoModifier);
     const auto keysyms = QXkbCommon::toKeysym(&dummy);
 
-    KeySym keysym = keysyms.isEmpty() ? XCB_NO_SYMBOL : keysyms.first();
+    xcb_keysym_t keysym = keysyms.isEmpty() ? XCB_NO_SYMBOL : keysyms.first();
     if (keysym == XCB_NO_SYMBOL) {
         keysym = static_cast<ushort>(key);
     }
@@ -140,9 +136,9 @@ quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key, quint32 &extraNativ
         // If the keysym at group 0, level 0 (no modifiers) differs from
         // our target, but group 0, level 1 (Shift) matches, then Shift
         // is an implicit modifier.
-        KeySym unshifted = xcb_key_symbols_get_keysym(xcbKeySymbols, native, 0);
+        xcb_keysym_t unshifted = xcb_key_symbols_get_keysym(xcbKeySymbols, native, 0);
         if (unshifted != keysym) {
-            KeySym shifted = xcb_key_symbols_get_keysym(xcbKeySymbols, native, 1);
+            xcb_keysym_t shifted = xcb_key_symbols_get_keysym(xcbKeySymbols, native, 1);
             if (shifted == keysym) {
                 extraNativeMods |= XCB_MOD_MASK_SHIFT;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched Unix keyboard shortcut backend to a modern XCB-based implementation for better compatibility with recent system libraries and Qt releases; simplified linking to reduce integration issues.
* **Bug Fixes**
  * More reliable interpretation of key symbols (shifted vs unshifted), improving detection of shortcuts on Unix.
* **Chores**
  * Added a graceful fallback when native system support is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->