### PR TITLE
build(cmake): add zeal_add_test helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ project(Zeal
 
 set(ZEAL_RELEASE_VERSION "0.8.1") # x-release-please-version
 
+include(ZealHelpers)
+
 option(ZEAL_USE_CLANG_TIDY "Enable clang-tidy static analysis" OFF)
 if(ZEAL_USE_CLANG_TIDY)
     find_program(CLANG_TIDY_PROGRAM clang-tidy)

--- a/cmake/ZealHelpers.cmake
+++ b/cmake/ZealHelpers.cmake
@@ -1,0 +1,22 @@
+#
+# ZealHelpers.cmake - Project-specific CMake helpers
+#
+# SPDX-FileCopyrightText: Oleg Shparber, et al. <https://zealdocs.org>
+# SPDX-License-Identifier: MIT
+#
+
+# Register a unit test executable. On Windows, prepends Qt's DLL directory to
+# PATH at test-run time so the test binary can locate Qt6Core.dll without
+# deploying Qt next to every test executable.
+#
+# TODO: Once cmake_minimum_required is >= 3.27, replace the Qt-specific
+# directory with $<TARGET_RUNTIME_DLL_DIRS:${test_name}> to cover any future
+# non-Qt shared dependencies automatically.
+function(zeal_add_test test_name)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+    if(WIN32)
+        set_tests_properties(${test_name} PROPERTIES
+            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt6::Core>"
+        )
+    endif()
+endfunction()

--- a/src/libs/util/tests/CMakeLists.txt
+++ b/src/libs/util/tests/CMakeLists.txt
@@ -4,4 +4,4 @@ find_package(Qt6 REQUIRED COMPONENTS Test)
 add_executable(fuzzy_test fuzzy_test.cpp)
 target_link_libraries(fuzzy_test PRIVATE Util Qt6::Test)
 
-add_test(NAME fuzzy_test COMMAND fuzzy_test)
+zeal_add_test(fuzzy_test)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized test registration introduced so test executables automatically get required runtime library paths on Windows, improving test reliability and avoiding manual DLL deployment.
  * Existing tests updated to use the centralized registration mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->