### PR TITLE
fix(registry): list symbols on empty query

### DIFF
--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -311,6 +311,28 @@ const QMultiMap<QString, QUrl> &Docset::symbols(const QString &symbolType) const
 
 QList<SearchResult> Docset::search(const QString &query, const std::atomic_bool &canceled) const
 {
+    if (query.isEmpty()) {
+        // Keyword prefix only (e.g. "html:") — list all symbols alphabetically.
+        const QString sql = m_type == Docset::Type::Dash
+                              ? QStringLiteral("SELECT name, type, path, '' FROM searchIndex ORDER BY name LIMIT 1000")
+                              : QStringLiteral(
+                                    "SELECT name, type, path, fragment FROM searchIndex ORDER BY name LIMIT 1000");
+        m_db->prepare(sql);
+
+        QList<SearchResult> results;
+        while (m_db->next() && !canceled.load(std::memory_order_relaxed)) {
+            results.append({.name = m_db->value(0).toString(),
+                            .type = parseSymbolType(m_db->value(1).toString()),
+                            .urlPath = m_db->value(2).toString(),
+                            .urlFragment = m_db->value(3).toString(),
+                            .docset = const_cast<Docset *>(this),
+                            .score = 0,
+                            .matchPositions = {}});
+        }
+
+        return results;
+    }
+
     QString sql;
     if (m_type == Docset::Type::Dash) {
         if (m_isFuzzySearchEnabled) {


### PR DESCRIPTION
Fixes #1839.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search now properly handles empty queries. When no search term is entered, the search displays available symbols ordered alphabetically by name, allowing users to browse the complete symbol list without requiring a search term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->