### PR TITLE
fix(ui): handle xcb_key_symbols_alloc failure

### DIFF
--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
+++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut_x11.cpp
@@ -140,6 +140,9 @@ quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key, quint32 &extraNativ
     }
 
     xcb_key_symbols_t *xcbKeySymbols = xcb_key_symbols_alloc(xcbConnection);
+    if (xcbKeySymbols == nullptr) {
+        return 0;
+    }
 
     QScopedPointer<xcb_keycode_t, QScopedPointerPodDeleter> keycodes(
         xcb_key_symbols_get_keycode(xcbKeySymbols, keysym));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of global keyboard shortcuts on X11 systems by adding defensive checks that prevent potential crashes from memory allocation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->