### PR TITLE
feat(ui): add Sidebar toggle to View menu

### DIFF
--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -147,6 +147,7 @@ void Settings::load()
 
     settings->beginGroup(GroupUI);
     hideMenuBar = settings->value(QStringLiteral("hide_menu_bar"), false).toBool();
+    hideSidebar = settings->value(QStringLiteral("hide_sidebar"), false).toBool();
     settings->endGroup();
 
     settings->beginGroup(GroupGlobalShortcuts);
@@ -299,6 +300,7 @@ void Settings::save()
 
     settings->beginGroup(GroupUI);
     settings->setValue(QStringLiteral("hide_menu_bar"), hideMenuBar);
+    settings->setValue(QStringLiteral("hide_sidebar"), hideSidebar);
     settings->endGroup();
 
     settings->beginGroup(GroupGlobalShortcuts);

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -25,6 +25,7 @@ public:
     bool startMinimized;
     bool checkForUpdate;
     bool hideMenuBar;
+    bool hideSidebar;
     // TODO: bool restoreLastState;
 
     // System Tray

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -87,6 +87,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent)
     // Setup splitter.
     m_splitter->insertWidget(0, sb);
     m_splitter->restoreState(windowState.splitterState);
+    sb->setVisible(m_showSidebarAction->isChecked());
 
     // Setup web settings.
     new Browser::Settings(m_settings, this);
@@ -361,8 +362,23 @@ void MainWindow::setupMainMenu()
         }
     });
 
-    menu->addSeparator();
 #endif
+
+    // -> Toggle Sidebar Action.
+    action = m_showSidebarAction = menu->addAction(tr("&Sidebar"));
+    addAction(action);
+    action->setCheckable(true);
+    action->setChecked(!m_settings->hideSidebar);
+    action->setShortcut(QKeySequence(QStringLiteral("Ctrl+B")));
+    connect(action, &QAction::toggled, this, [this](bool checked) {
+        if (auto *sb = m_splitter->widget(0)) {
+            sb->setVisible(checked);
+        }
+        m_settings->hideSidebar = !checked;
+        m_settings->save();
+    });
+
+    menu->addSeparator();
 
     // -> Zoom Submenu.
     auto *zoomMenu = menu->addMenu(tr("&Zoom"));
@@ -461,19 +477,6 @@ void MainWindow::setupShortcuts()
     shortcut = new QShortcut(QStringLiteral("Ctrl+Alt+T"), this);
     connect(shortcut, &QShortcut::activated, this, [this]() {
         duplicateTab(m_tabBar->currentIndex());
-    });
-
-    // Hide/show sidebar.
-    // TODO: Move to the View menu.
-    shortcut = new QShortcut(QStringLiteral("Ctrl+B"), this);
-    connect(shortcut, &QShortcut::activated, this, [this]() {
-        auto *sb = m_splitter->widget(0);
-        if (sb == nullptr) {
-            // This should not really happen.
-            return;
-        }
-
-        sb->setVisible(!sb->isVisible());
     });
 
     // Browser Shortcuts.

--- a/src/libs/ui/mainwindow.h
+++ b/src/libs/ui/mainwindow.h
@@ -92,6 +92,7 @@ private:
     // TODO: Replace with proper action manager.
     QAction *m_showDocsetManagerAction = nullptr;
     QAction *m_showPreferencesAction = nullptr;
+    QAction *m_showSidebarAction = nullptr;
 #ifndef Q_OS_MACOS
     QAction *m_showMenuBarAction = nullptr;
 #endif


### PR DESCRIPTION
Fixes #1791.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sidebar toggle in the View menu for convenient visibility control
  * Sidebar visibility preference is now saved and restored on app restart

<!-- end of auto-generated comment: release notes by coderabbit.ai -->