### PR TITLE
build(cmake): scope ZEAL_VERSION to App target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,9 +10,6 @@ if(ZEAL_PORTABLE_BUILD)
     add_definitions(-DPORTABLE_BUILD)
 endif()
 
-## Macros.
-add_definitions(-DZEAL_VERSION="${ZEAL_VERSION_FULL}")
-
 # QString options
 add_definitions(-DQT_USE_QSTRINGBUILDER)
 add_definitions(-DQT_RESTRICTED_CAST_FROM_ASCII)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -35,6 +35,10 @@ qt_add_executable(App WIN32
 
 target_link_libraries(App PRIVATE Core Ui Util Qt6::Widgets)
 
+# Scoped here (not project-wide) so changes to the version string don't
+# invalidate compiler caches for every TU on every commit.
+target_compile_definitions(App PRIVATE ZEAL_VERSION="${ZEAL_VERSION_FULL}")
+
 set_target_properties(App PROPERTIES
     OUTPUT_NAME ${_project_output_name}
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for version macro handling to improve build efficiency without affecting functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1853)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->