### PR TITLE
fix(core,ui): unbundle style apply from save()

### DIFF
--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -355,10 +355,6 @@ void Settings::save()
 
     settings->sync();
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-    applyColorScheme();
-#endif
-
     emit updated();
 }
 

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -120,6 +120,10 @@ public:
 
     static ColorScheme colorScheme();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    void applyColorScheme();
+#endif
+
 public slots:
     void load();
     void save();
@@ -129,9 +133,6 @@ signals:
 
 private:
     void migrate(QSettings *settings) const;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-    void applyColorScheme();
-#endif
 
     static QSettings *qsettings(QObject *parent = nullptr);
 };

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -329,6 +329,10 @@ void SettingsDialog::saveSettings()
     settings->isIgnoreSslErrorsEnabled = ui->ignoreSslErrorsCheckBox->isChecked();
 
     settings->save();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    settings->applyColorScheme();
+#endif
 }
 
 } // namespace Zeal::WidgetUi


### PR DESCRIPTION
Fixes #1858.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Adjusted color scheme application logic for improved compatibility with Qt 6.5.0 and later versions, ensuring color preferences are applied correctly in the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1860)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->