### PR TITLE
refactor(registry): simplify index resolution

### DIFF
--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -192,26 +192,25 @@ Docset::Docset(QString path)
 
     m_keywords.removeDuplicates();
 
-    // Determine index page. This is ridiculous.
-    const QString mdIndexFilePath = m_indexFilePath; // Save path from the metadata.
+    // Determine index page: prefer docset's plist, then metadata, then index.html.
+    QString indexFilePath;
 
-    // Prefer index path provided by the docset.
     if (plist.contains(InfoPlist::DashIndexFilePath)) {
-        const QString indexFilePath = plist[InfoPlist::DashIndexFilePath].toString();
-        if (dir.exists(indexFilePath)) {
-            m_indexFilePath = indexFilePath;
+        const QString candidate = plist[InfoPlist::DashIndexFilePath].toString();
+        if (dir.exists(candidate)) {
+            indexFilePath = candidate;
         }
     }
 
-    // Check the metadata.
-    if (m_indexFilePath.isEmpty() && !mdIndexFilePath.isEmpty() && dir.exists(mdIndexFilePath)) {
-        m_indexFilePath = mdIndexFilePath;
+    if (indexFilePath.isEmpty() && !m_indexFilePath.isEmpty() && dir.exists(m_indexFilePath)) {
+        indexFilePath = m_indexFilePath;
     }
 
-    // What if there is index.html.
-    if (m_indexFilePath.isEmpty() && dir.exists(QStringLiteral("index.html"))) {
-        m_indexFilePath = QStringLiteral("index.html");
+    if (indexFilePath.isEmpty() && dir.exists(QStringLiteral("index.html"))) {
+        indexFilePath = QStringLiteral("index.html");
     }
+
+    m_indexFilePath = indexFilePath;
 
     // Log if unable to determine the index page. Otherwise the path will be set in setBaseUrl().
     if (m_indexFilePath.isEmpty()) {


### PR DESCRIPTION
## Summary

- Replace the snapshot-then-mutate pattern in `Docset::loadMetadata`'s index-path resolution with a local accumulator, consolidating the priority order (plist → metadata → `index.html`) and assigning to `m_indexFilePath` once at the end.
- Drops the dead-code fallback at the old line 207: with the previous structure, `m_indexFilePath` could only be empty there if it was already empty before the snapshot, so the `mdIndexFilePath` fallback was never reachable. The new code makes that fallback live — if plist contains `DashIndexFilePath` but the file doesn't exist on disk, and metadata has a usable path, we now use the metadata path. Functionally a small bugfix.
- Removes the "This is ridiculous." comment 🙃

Discovered via a one-off Infer (Pulse) run that flagged the snapshot as `PULSE_UNNECESSARY_COPY`. The copy itself wasn't unnecessary in the literal sense (the snapshot was load-bearing), but the surrounding code was tangled enough that restructuring removed the snapshot need entirely.

## Test plan

- [ ] Open an existing docset whose `meta.json` provides `indexFilePath` and `Info.plist` provides a matching valid `DashIndexFilePath` → plist path used (unchanged behavior).
- [ ] Open a docset whose `Info.plist` provides `DashIndexFilePath` but the file doesn't exist on disk, and `meta.json` provides a valid `indexFilePath` → metadata path now used (previously the docset would log "Cannot determine index file" or fall to `index.html`).
- [ ] Open a docset with no `meta.json` indexFilePath and no valid plist path → falls back to `index.html` if present (unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved docset index file selection logic to enhance reliability when loading documentation sets with varying configurations. The system now checks multiple sources sequentially to identify the correct index file, ensuring better compatibility and more consistent behavior across different documentation formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1861)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->