### PR TITLE
fix(registry): drop raw Docset* from SearchResult

### DIFF
--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -278,7 +278,7 @@ QIcon Docset::icon() const
     return m_icon;
 }
 
-QIcon Docset::symbolTypeIcon(const QString &symbolType) const
+QIcon Docset::symbolTypeIcon(const QString &symbolType)
 {
     static const QIcon unknownIcon(QStringLiteral("typeIcon:Unknown.png"));
 
@@ -323,9 +323,9 @@ QList<SearchResult> Docset::search(const QString &query, const std::atomic_bool 
         while (stmt.step() && !canceled.load(std::memory_order_relaxed)) {
             results.append({.name = stmt.value(0).toString(),
                             .type = parseSymbolType(stmt.value(1).toString()),
-                            .urlPath = stmt.value(2).toString(),
-                            .urlFragment = stmt.value(3).toString(),
-                            .docset = const_cast<Docset *>(this),
+                            .url = createPageUrl(stmt.value(2).toString(), stmt.value(3).toString()),
+                            .docsetName = m_name,
+                            .docsetIcon = m_icon,
                             .score = 0,
                             .matchPositions = {}});
         }
@@ -380,9 +380,9 @@ QList<SearchResult> Docset::search(const QString &query, const std::atomic_bool 
         SearchResult result;
         result.name = stmt.value(0).toString();
         result.type = parseSymbolType(stmt.value(1).toString());
-        result.urlPath = stmt.value(2).toString();
-        result.urlFragment = stmt.value(3).toString();
-        result.docset = const_cast<Docset *>(this);
+        result.url = createPageUrl(stmt.value(2).toString(), stmt.value(3).toString());
+        result.docsetName = m_name;
+        result.docsetIcon = m_icon;
         result.score = stmt.value(4).toDouble();
 
         // Compute match positions for highlighting.
@@ -438,13 +438,13 @@ QList<SearchResult> Docset::relatedLinks(const QUrl &url) const
     }
 
     while (stmt.step()) {
-        results.append({stmt.value(0).toString(),
-                        parseSymbolType(stmt.value(1).toString()),
-                        stmt.value(2).toString(),
-                        stmt.value(3).toString(),
-                        const_cast<Docset *>(this),
-                        0,
-                        {}});
+        results.append({.name = stmt.value(0).toString(),
+                        .type = parseSymbolType(stmt.value(1).toString()),
+                        .url = createPageUrl(stmt.value(2).toString(), stmt.value(3).toString()),
+                        .docsetName = m_name,
+                        .docsetIcon = m_icon,
+                        .score = 0,
+                        .matchPositions = {}});
     }
 
     if (results.size() == 1) {
@@ -452,11 +452,6 @@ QList<SearchResult> Docset::relatedLinks(const QUrl &url) const
     }
 
     return results;
-}
-
-QUrl Docset::searchResultUrl(const SearchResult &result) const
-{
-    return createPageUrl(result.urlPath, result.urlFragment);
 }
 
 void Docset::loadMetadata()

--- a/src/libs/registry/docset.h
+++ b/src/libs/registry/docset.h
@@ -45,7 +45,7 @@ public:
     QString path() const;
     QString documentPath() const;
     QIcon icon() const;
-    QIcon symbolTypeIcon(const QString &symbolType) const;
+    static QIcon symbolTypeIcon(const QString &symbolType);
     QUrl indexFileUrl() const;
 
     QMap<QString, int> symbolCounts() const;
@@ -55,9 +55,6 @@ public:
 
     QList<SearchResult> search(const QString &query, const std::atomic_bool &canceled) const;
     QList<SearchResult> relatedLinks(const QUrl &url) const;
-
-    // FIXME: This a temporary solution to create URL on demand.
-    QUrl searchResultUrl(const SearchResult &result) const;
 
     // FIXME: This is an ugly workaround before we have a proper docset sources implementation
     bool hasUpdate = false;

--- a/src/libs/registry/searchmodel.cpp
+++ b/src/libs/registry/searchmodel.cpp
@@ -39,16 +39,16 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const
         return item->name;
 
     case Qt::DecorationRole:
-        return item->docset->symbolTypeIcon(item->type);
+        return Docset::symbolTypeIcon(item->type);
 
     case ItemDataRole::DocsetIconRole:
-        return item->docset->icon();
+        return item->docsetIcon;
 
     case ItemDataRole::MatchPositionsRole:
         return QVariant::fromValue(item->matchPositions);
 
     case ItemDataRole::UrlRole:
-        return item->docset->searchResultUrl(*item);
+        return item->url;
 
     default:
         return QVariant();
@@ -94,7 +94,7 @@ void SearchModel::removeSearchResultWithName(const QString &name)
 
     int rowNum = 0;
     while (iterator.hasNext()) {
-        if (iterator.next().docset->name() == name) {
+        if (iterator.next().docsetName == name) {
             beginRemoveRows(QModelIndex(), rowNum, rowNum);
             iterator.remove();
             rowNum -= 1;

--- a/src/libs/registry/searchresult.h
+++ b/src/libs/registry/searchresult.h
@@ -5,23 +5,22 @@
 #ifndef ZEAL_REGISTRY_SEARCHRESULT_H
 #define ZEAL_REGISTRY_SEARCHRESULT_H
 
+#include <QIcon>
 #include <QList>
 #include <QString>
 #include <QUrl>
 
 namespace Zeal::Registry {
 
-class Docset;
-
 struct SearchResult
 {
     QString name;
     QString type;
 
-    QString urlPath;
-    QString urlFragment;
+    QUrl url;
 
-    Docset *docset;
+    QString docsetName;
+    QIcon docsetIcon;
 
     double score;
     QList<int> matchPositions;


### PR DESCRIPTION
## Summary

`SearchResult` held a raw `Docset *` that `SearchModel` dereferenced at render time. Any path that destroys a `Docset` between search-time and navigation crashes on a dangling pointer — realistically, an incoming `dash://` URL forwarded via the single-instance IPC while "Update all" is unloading docsets (modal dialogs don't block the event loop).

Sibling bug to #1858 — same `SearchModel` field, different deref site.

## Fix

Precompute the full `QUrl` and capture the docset icon at search time; keep `docsetName` for `removeSearchResultWithName` matching. Make `Docset::symbolTypeIcon` `static` and drop the now-unused `Docset::searchResultUrl`. `SearchModel::data()` no longer dereferences a `Docset *` for any role — the bug class is removed structurally rather than via defensive null checks.

## References

- [Red Hat Bugzilla #2388178](https://bugzilla.redhat.com/show_bug.cgi?id=2388178) — exact stack match on Fedora 42 / `zeal-0.7.2-9.fc42`.

## Test plan

- [ ] Repro under Page Heap (Windows) or glibc malloc check / ASan (Linux): install 2+ docsets → start a search that returns results → click "Update all" in the Docsets dialog → externally trigger navigation via a `dash://` URL while update is in flight. Navigation should follow the precomputed `QUrl` instead of touching the freed `Docset`.
- [ ] `ctest --preset testing` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal search result data handling for better efficiency and maintainability.
  * Streamlined URL generation within search operations.
  * Optimized search model data retrieval and filtering logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1863)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->