### PR TITLE
build(tools): add clazy integration

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,6 +45,11 @@ format *args:
 lint *args: configure
     pwsh tools/run-clang-tidy.ps1 {{args}}
 
+# Run clazy Qt-aware checks (use -Fix to apply, -Staged for staged files only, -Check <name> for a single check or level).
+[group('dev')]
+clazy *args: configure
+    pwsh tools/run-clazy.ps1 {{args}}
+
 # Remove all build directories.
 [group('dev')]
 clean:

--- a/tools/run-clazy.ps1
+++ b/tools/run-clazy.ps1
@@ -1,0 +1,109 @@
+#
+# run-clazy.ps1 - Run clazy (Qt-aware static analysis) on the codebase
+#
+# SPDX-FileCopyrightText: Oleg Shparber, et al. <https://zealdocs.org>
+# SPDX-License-Identifier: MIT
+#
+# By default, runs clazy-standalone with the "level1" check group.
+# Use -Check <name> to run a specific check (e.g., -Check qstring-allocations)
+# or a different group (e.g., -Check level2).
+#
+# Check list: https://github.com/KDE/clazy/blob/master/README.md#list-of-checks
+# Use -Fix to apply suggested fixes (requires clang-apply-replacements).
+# Use -Staged to only process files staged for commit.
+# Use -Verbose to print each file being processed.
+#
+# Requires a compile_commands.json in the build directory (build/dev).
+#
+
+[CmdletBinding()]
+param(
+    [string]$Check,
+    [switch]$Fix,
+    [switch]$Staged
+)
+
+$buildDir = Join-Path -Path $PSScriptRoot -ChildPath "..\build\dev"
+
+if (-not (Test-Path "$buildDir/compile_commands.json")) {
+    Write-Error "compile_commands.json not found in $buildDir. Run 'cmake --preset dev' first."
+    exit 1
+}
+
+$buildDir = Resolve-Path $buildDir
+
+if (-not (Get-Command clazy-standalone -ErrorAction SilentlyContinue)) {
+    Write-Error "clazy-standalone not found in PATH."
+    exit 1
+}
+
+$checks = if ($Check) { $Check } else { "level1" }
+# -Wno-error keeps project -Werror flags from aborting a TU before clazy can
+# report all findings (e.g., Qt 6.4 QT_REQUIRE_VERSION trips -Wdeprecated-declarations).
+$clazyArgs = @("-p", $buildDir, "--checks=$checks", "--header-filter=.*[/\\]src[/\\].*", "--extra-arg=-Wno-error")
+
+$fixesDir = $null
+if ($Fix) {
+    if (-not (Get-Command clang-apply-replacements -ErrorAction SilentlyContinue)) {
+        Write-Error "clang-apply-replacements not found in PATH (required for -Fix)."
+        exit 1
+    }
+    $fixesDir = Join-Path ([System.IO.Path]::GetTempPath()) "zeal-clazy-fixes-$PID"
+    New-Item -ItemType Directory -Path $fixesDir | Out-Null
+}
+
+$srcDir = Join-Path -Path $PSScriptRoot -ChildPath "..\src"
+
+# Only process files present in compile_commands.json to skip platform-specific files.
+$compileDb = Get-Content "$buildDir/compile_commands.json" | ConvertFrom-Json
+$dbFiles = $compileDb | ForEach-Object { [System.IO.Path]::GetFullPath($_.file) }
+
+if ($Staged) {
+    $files = git diff --cached --name-only --diff-filter=ACMR -- "*.cpp" |
+        ForEach-Object { Join-Path -Path $PSScriptRoot -ChildPath ".." -AdditionalChildPath $_ } |
+        Where-Object { Test-Path $_ } |
+        ForEach-Object { [System.IO.Path]::GetFullPath($_) } |
+        Where-Object { $_ -in $dbFiles }
+} else {
+    $excludeDir = Join-Path -Path $srcDir -ChildPath "contrib"
+    $files = Get-ChildItem -Recurse $srcDir -Include *.cpp |
+        Where-Object { -not $_.FullName.StartsWith($excludeDir) -and $_.FullName -in $dbFiles } |
+        Select-Object -ExpandProperty FullName
+}
+
+if (-not $files) {
+    Write-Information "No files to process."
+    exit 0
+}
+
+$failed = $false
+try {
+    $i = 0
+    foreach ($file in $files) {
+        Write-Verbose "Processing $file"
+        $perFileArgs = $clazyArgs
+        if ($Fix) {
+            $perFileArgs = $perFileArgs + @("--export-fixes=$fixesDir/$i.yaml")
+        }
+        & clazy-standalone @perFileArgs $file
+        if ($LASTEXITCODE -ne 0) {
+            $failed = $true
+        }
+        $i++
+    }
+
+    if ($Fix) {
+        & clang-apply-replacements $fixesDir
+        if ($LASTEXITCODE -ne 0) {
+            $failed = $true
+        }
+    }
+} finally {
+    if ($fixesDir -and (Test-Path $fixesDir)) {
+        Remove-Item -Recurse -Force $fixesDir
+    }
+}
+
+if ($failed) {
+    exit 1
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Qt-aware static analysis task for C++ that can run checks at selectable levels.
  * Task supports restricting to staged files and an option to apply exported fixes automatically.
  * Validates prerequisites before running and returns nonzero exit codes on failures to surface issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1869)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->