### PR TITLE
refactor(registry): drop SearchModel const_cast

### DIFF
--- a/src/libs/registry/searchmodel.cpp
+++ b/src/libs/registry/searchmodel.cpp
@@ -28,27 +28,27 @@ bool SearchModel::isEmpty() const
 
 QVariant SearchModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid()) {
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_dataList.count()) {
         return QVariant();
     }
 
-    auto *item = static_cast<SearchResult *>(index.internalPointer());
+    const SearchResult &item = m_dataList.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
-        return item->name;
+        return item.name;
 
     case Qt::DecorationRole:
-        return Docset::symbolTypeIcon(item->type);
+        return Docset::symbolTypeIcon(item.type);
 
     case ItemDataRole::DocsetIconRole:
-        return item->docsetIcon;
+        return item.docsetIcon;
 
     case ItemDataRole::MatchPositionsRole:
-        return QVariant::fromValue(item->matchPositions);
+        return QVariant::fromValue(item.matchPositions);
 
     case ItemDataRole::UrlRole:
-        return item->url;
+        return item.url;
 
     default:
         return QVariant();
@@ -61,9 +61,7 @@ QModelIndex SearchModel::index(int row, int column, const QModelIndex &parent) c
         return {};
     }
 
-    // FIXME: const_cast
-    auto *item = const_cast<SearchResult *>(&m_dataList.at(row));
-    return createIndex(row, column, item);
+    return createIndex(row, column);
 }
 
 int SearchModel::rowCount(const QModelIndex &parent) const


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal changes to the search model improve safety and clarity without altering visible behavior — display names, icons, match highlights, and result URLs remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1870)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->