### PR TITLE
build(cmake,just): add ClangBuildAnalyzer recipe

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,6 +72,34 @@
     {
       "name": "testing",
       "inherits": ["debug", "config-testing"]
+    },
+    {
+      "name": "timetrace-windows",
+      "inherits": ["release"],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "CMAKE_CXX_FLAGS": "/clang:-ftime-trace /EHsc"
+      }
+    },
+    {
+      "name": "timetrace-unix",
+      "inherits": ["release"],
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CXX_FLAGS": "-ftime-trace"
+      }
     }
   ],
   "buildPresets": [
@@ -102,6 +130,14 @@
     {
       "name": "testing",
       "configurePreset": "testing"
+    },
+    {
+      "name": "timetrace-windows",
+      "configurePreset": "timetrace-windows"
+    },
+    {
+      "name": "timetrace-unix",
+      "configurePreset": "timetrace-unix"
     }
   ],
   "testPresets": [

--- a/justfile
+++ b/justfile
@@ -9,6 +9,9 @@ set positional-arguments
 # Default build preset; override with `just preset=name <recipe>`.
 preset := env_var_or_default("PRESET", "dev")
 
+# OS-specific preset selector for the build-time profiler.
+timetrace_preset := if os() == "windows" { "timetrace-windows" } else { "timetrace-unix" }
+
 [private]
 default:
     @just --list
@@ -49,6 +52,20 @@ lint *args: configure
 [group('dev')]
 clazy *args: configure
     pwsh tools/run-clazy.ps1 {{args}}
+
+# Profile build time with -ftime-trace and emit a ClangBuildAnalyzer report.
+# Requires Clang (clang-cl on Windows) and ClangBuildAnalyzer on PATH.
+[group('dev')]
+analyze-build-time:
+    cmake --preset {{timetrace_preset}}
+    cmake --build --preset {{timetrace_preset}}
+    ClangBuildAnalyzer --all build/{{timetrace_preset}} build/{{timetrace_preset}}/cba.bin
+    ClangBuildAnalyzer --analyze build/{{timetrace_preset}}/cba.bin
+
+# Re-emit the ClangBuildAnalyzer report from an existing timetrace build.
+[group('dev')]
+analyze-build-time-report:
+    ClangBuildAnalyzer --analyze build/{{timetrace_preset}}/cba.bin
 
 # Remove all build directories.
 [group('dev')]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build-time profiling presets for Windows and Unix environments in CMake configuration.
  * Introduced new development recipes for build-time performance analysis and reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1874)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->