### PR TITLE
build(cmake): precompile common Qt headers

### DIFF
--- a/cmake/ZealHelpers.cmake
+++ b/cmake/ZealHelpers.cmake
@@ -20,3 +20,10 @@ function(zeal_add_test test_name)
         )
     endif()
 endfunction()
+
+# Attach the project's standard Qt precompiled-header set to a target. Every
+# target receives <QObject> and <QString>; additional headers may be passed as
+# extra arguments (e.g. zeal_attach_qt_pch(Ui <QDialog> <QWidget>)).
+function(zeal_attach_qt_pch target)
+    target_precompile_headers(${target} PRIVATE <QObject> <QString> ${ARGN})
+endfunction()

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -35,6 +35,8 @@ qt_add_executable(App WIN32
 
 target_link_libraries(App PRIVATE Core Ui Util Qt6::Svg Qt6::Widgets)
 
+zeal_attach_qt_pch(App <QWidget>)
+
 # Scoped here (not project-wide) so changes to the version string don't
 # invalidate compiler caches for every TU on every commit.
 target_compile_definitions(App PRIVATE ZEAL_VERSION="${ZEAL_VERSION_FULL}")

--- a/src/libs/browser/CMakeLists.txt
+++ b/src/libs/browser/CMakeLists.txt
@@ -10,3 +10,5 @@ add_library(Browser STATIC
 
 find_package(Qt6 COMPONENTS WebChannel WebEngineWidgets REQUIRED)
 target_link_libraries(Browser PRIVATE Qt6::WebChannel Qt6::WebEngineWidgets)
+
+zeal_attach_qt_pch(Browser <QWidget>)

--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(Core PRIVATE
     Qt6::Widgets
 )
 
+zeal_attach_qt_pch(Core <QDir>)
+
 find_package(LibArchive QUIET)
 if(NOT LibArchive_FOUND)
     find_path(LibArchive_INCLUDE_DIRS archive.h

--- a/src/libs/registry/CMakeLists.txt
+++ b/src/libs/registry/CMakeLists.txt
@@ -18,3 +18,5 @@ target_link_libraries(Registry PRIVATE
     Qt6::Gui
     Qt6::Network
 )
+
+zeal_attach_qt_pch(Registry <QIcon>)

--- a/src/libs/sidebar/CMakeLists.txt
+++ b/src/libs/sidebar/CMakeLists.txt
@@ -7,3 +7,5 @@ add_library(Sidebar STATIC
 
 find_package(Qt6 COMPONENTS Widgets REQUIRED)
 target_link_libraries(Sidebar PRIVATE Qt6::Widgets)
+
+zeal_attach_qt_pch(Sidebar <QWidget>)

--- a/src/libs/ui/CMakeLists.txt
+++ b/src/libs/ui/CMakeLists.txt
@@ -23,5 +23,7 @@ add_library(Ui STATIC
 
 target_link_libraries(Ui PRIVATE Browser Sidebar QxtGlobalShortcut Widgets Registry Util)
 
+zeal_attach_qt_pch(Ui <QDialog> <QWidget>)
+
 find_package(Qt6 COMPONENTS WebEngineWidgets REQUIRED)
 target_link_libraries(Ui PRIVATE Qt6::WebEngineWidgets)

--- a/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
+++ b/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(QxtGlobalShortcut STATIC ${QxtGlobalShortcut_SOURCES})
 find_package(Qt6 COMPONENTS Gui REQUIRED)
 target_link_libraries(QxtGlobalShortcut PRIVATE Qt6::Gui)
 
+zeal_attach_qt_pch(QxtGlobalShortcut <QKeySequence>)
+
 if(APPLE)
     find_library(CARBON_LIBRARY Carbon)
     target_link_libraries(QxtGlobalShortcut PRIVATE ${CARBON_LIBRARY})

--- a/src/libs/ui/widgets/CMakeLists.txt
+++ b/src/libs/ui/widgets/CMakeLists.txt
@@ -8,3 +8,5 @@ add_library(Widgets STATIC
 
 find_package(Qt6 COMPONENTS Widgets REQUIRED)
 target_link_libraries(Widgets PRIVATE Qt6::Widgets)
+
+zeal_attach_qt_pch(Widgets <QWidget>)

--- a/src/libs/util/CMakeLists.txt
+++ b/src/libs/util/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(Util STATIC
 find_package(Qt6 COMPONENTS Core REQUIRED)
 target_link_libraries(Util PRIVATE Qt6::Core)
 
+zeal_attach_qt_pch(Util)
+
 find_package(SQLite3 REQUIRED)
 if(NOT TARGET SQLite3::SQLite3)
     add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build system by enabling Qt precompiled headers across all application and library targets. This configuration change accelerates compilation, reducing build times without affecting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1875)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->