### PR TITLE
refactor: modernize constexpr string constants

### DIFF
--- a/src/libs/browser/settings.cpp
+++ b/src/libs/browser/settings.cpp
@@ -19,7 +19,9 @@ namespace Zeal::Browser {
 namespace {
 Q_LOGGING_CATEGORY(log, "zeal.browser.settings")
 
-constexpr char HighlightOnNavigateCssPath[] = ":/browser/assets/css/highlight.css";
+using Qt::Literals::StringLiterals::operator""_L1;
+
+constexpr auto HighlightOnNavigateCssPath = ":/browser/assets/css/highlight.css"_L1;
 } // namespace
 
 QWebEngineProfile *Settings::m_webProfile = nullptr;

--- a/src/libs/core/application.cpp
+++ b/src/libs/core/application.cpp
@@ -27,7 +27,9 @@
 namespace Zeal::Core {
 
 namespace {
-constexpr char ReleasesApiUrl[] = "https://api.zealdocs.org/v1/releases";
+using Qt::Literals::StringLiterals::operator""_L1;
+
+constexpr auto ReleasesApiUrl = "https://api.zealdocs.org/v1/releases"_L1;
 } // namespace
 
 Application *Application::m_instance = nullptr;

--- a/src/libs/core/httpserver.cpp
+++ b/src/libs/core/httpserver.cpp
@@ -18,7 +18,7 @@ namespace Zeal::Core {
 namespace {
 Q_LOGGING_CATEGORY(log, "zeal.core.httpserver")
 
-constexpr char LocalHttpServerHost[] = "127.0.0.1"; // macOS only routes 127.0.0.1 by default.
+constexpr const char *LocalHttpServerHost = "127.0.0.1"; // macOS only routes 127.0.0.1 by default.
 } // namespace
 
 HttpServer::HttpServer(QObject *parent)
@@ -29,7 +29,7 @@ HttpServer::HttpServer(QObject *parent)
     const int port = m_server->bind_to_any_port(LocalHttpServerHost);
 
     m_baseUrl.setScheme(QStringLiteral("http"));
-    m_baseUrl.setHost(LocalHttpServerHost);
+    m_baseUrl.setHost(QString::fromLatin1(LocalHttpServerHost));
     m_baseUrl.setPort(port);
 
     // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape): false positive — cpp-httplib stores the handler by value.

--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -30,15 +30,17 @@ namespace Zeal::Core {
 namespace {
 Q_LOGGING_CATEGORY(log, "zeal.core.settings")
 
+using Qt::Literals::StringLiterals::operator""_L1;
+
 // Configuration file groups
-constexpr char GroupUI[] = "ui";
-constexpr char GroupContent[] = "content";
-constexpr char GroupDocsets[] = "docsets";
-constexpr char GroupGlobalShortcuts[] = "global_shortcuts";
-constexpr char GroupSearch[] = "search";
-constexpr char GroupTabs[] = "tabs";
-constexpr char GroupInternal[] = "internal";
-constexpr char GroupProxy[] = "proxy";
+constexpr auto GroupUI = "ui"_L1;
+constexpr auto GroupContent = "content"_L1;
+constexpr auto GroupDocsets = "docsets"_L1;
+constexpr auto GroupGlobalShortcuts = "global_shortcuts"_L1;
+constexpr auto GroupSearch = "search"_L1;
+constexpr auto GroupTabs = "tabs"_L1;
+constexpr auto GroupInternal = "internal"_L1;
+constexpr auto GroupProxy = "proxy"_L1;
 } // namespace
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init): initialized by load().

--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -35,18 +35,18 @@ using Qt::Literals::StringLiterals::operator""_L1;
 constexpr auto IndexNamePrefix = "__zi_name"_L1; // zi - Zeal index
 constexpr auto IndexNameVersion = "0001"_L1;     // Current index version
 
-constexpr char NotFoundPageUrl[] = "qrc:///browser/404.html";
+constexpr auto NotFoundPageUrl = "qrc:///browser/404.html"_L1;
 
 namespace InfoPlist {
-constexpr char CFBundleName[] = "CFBundleName";
+constexpr auto CFBundleName = "CFBundleName"_L1;
 // const char CFBundleIdentifier[] = "CFBundleIdentifier";
-constexpr char DashDocSetFamily[] = "DashDocSetFamily";
-constexpr char DashDocSetKeyword[] = "DashDocSetKeyword";
-constexpr char DashDocSetPluginKeyword[] = "DashDocSetPluginKeyword";
-constexpr char DashIndexFilePath[] = "dashIndexFilePath";
-constexpr char DocSetPlatformFamily[] = "DocSetPlatformFamily";
+constexpr auto DashDocSetFamily = "DashDocSetFamily"_L1;
+constexpr auto DashDocSetKeyword = "DashDocSetKeyword"_L1;
+constexpr auto DashDocSetPluginKeyword = "DashDocSetPluginKeyword"_L1;
+constexpr auto DashIndexFilePath = "dashIndexFilePath"_L1;
+constexpr auto DocSetPlatformFamily = "DocSetPlatformFamily"_L1;
 // const char IsDashDocset[] = "isDashDocset";
-constexpr char IsJavaScriptEnabled[] = "isJavaScriptEnabled";
+constexpr auto IsJavaScriptEnabled = "isJavaScriptEnabled"_L1;
 } // namespace InfoPlist
 
 void sqliteScoreFunction(sqlite3_context *context, int argc, sqlite3_value **argv)

--- a/src/libs/ui/browsertab.cpp
+++ b/src/libs/ui/browsertab.cpp
@@ -28,7 +28,9 @@
 namespace Zeal::WidgetUi {
 
 namespace {
-constexpr char WelcomePageUrl[] = "qrc:///browser/welcome.html";
+using Qt::Literals::StringLiterals::operator""_L1;
+
+constexpr auto WelcomePageUrl = "qrc:///browser/welcome.html"_L1;
 } // namespace
 
 BrowserTab::BrowserTab(QWidget *parent)

--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -37,16 +37,18 @@ namespace Zeal::WidgetUi {
 namespace {
 Q_LOGGING_CATEGORY(log, "zeal.widgetui.docsetsdialog")
 
+using Qt::Literals::StringLiterals::operator""_L1;
+
 enum class DownloadType {
     DashFeed,
     Docset,
     DocsetList
 };
 
-constexpr char ApiServerUrl[] = "https://api.zealdocs.org/v1";
-constexpr char RedirectServerUrl[] = "https://go.zealdocs.org/d/%1/%2/latest";
+constexpr auto ApiServerUrl = "https://api.zealdocs.org/v1"_L1;
+constexpr auto RedirectServerUrl = "https://go.zealdocs.org/d/%1/%2/latest"_L1;
 // TODO: Each source plugin should have its own cache
-constexpr char DocsetListCacheFileName[] = "com.kapeli.json";
+constexpr auto DocsetListCacheFileName = "com.kapeli.json"_L1;
 
 // TODO: Make the timeout period configurable
 constexpr int CacheTimeout = 24 * 60 * 60; // 24 hours in seconds
@@ -55,9 +57,9 @@ constexpr int CacheTimeout = 24 * 60 * 60; // 24 hours in seconds
 constexpr qint64 DownloadChunkSize = 1024LL * 1024; // 1 MiB
 
 // QNetworkReply properties
-constexpr char DocsetNameProperty[] = "docsetName";
-constexpr char DownloadTypeProperty[] = "downloadType";
-constexpr char ListItemIndexProperty[] = "listItem";
+constexpr const char *DocsetNameProperty = "docsetName";
+constexpr const char *DownloadTypeProperty = "downloadType";
+constexpr const char *ListItemIndexProperty = "listItem";
 
 void setDownloadType(QNetworkReply *reply, DownloadType type)
 {

--- a/src/libs/util/database.cpp
+++ b/src/libs/util/database.cpp
@@ -11,18 +11,18 @@
 namespace Zeal::Util {
 
 namespace {
-constexpr char ListTablesSql[] = "SELECT name"
-                                 "  FROM"
-                                 "    (SELECT * FROM sqlite_master UNION ALL"
-                                 "    SELECT * FROM sqlite_temp_master)"
-                                 "  WHERE type='table'"
-                                 "  ORDER BY name";
-constexpr char ListViewsSql[] = "SELECT name"
-                                "  FROM"
-                                "    (SELECT * FROM sqlite_master UNION ALL"
-                                "    SELECT * FROM sqlite_temp_master)"
-                                "  WHERE type='view'"
-                                "  ORDER BY name";
+constexpr const char *ListTablesSql = "SELECT name"
+                                      "  FROM"
+                                      "    (SELECT * FROM sqlite_master UNION ALL"
+                                      "    SELECT * FROM sqlite_temp_master)"
+                                      "  WHERE type='table'"
+                                      "  ORDER BY name";
+constexpr const char *ListViewsSql = "SELECT name"
+                                     "  FROM"
+                                     "    (SELECT * FROM sqlite_master UNION ALL"
+                                     "    SELECT * FROM sqlite_temp_master)"
+                                     "  WHERE type='view'"
+                                     "  ORDER BY name";
 
 // sqlite3_exec() callback used in tables() and views().
 const auto ListCallback = [](void *ptr, int, char **data, char **) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized internal string literals across multiple modules to use Qt's optimized string literal format for improved code consistency and performance, with no changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->