### PR TITLE
build(cmake): auto-detect Homebrew prefix

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -202,7 +202,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Dependencies
-        run: brew install libarchive
+        run: brew install cpp-httplib libarchive tomlplusplus
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.25.1)
 include(cmake/SetupVcpkg.cmake)
 setup_vcpkg()
 
+include(cmake/SetupHomebrew.cmake)
+setup_homebrew()
+
 # CMake options.
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_DISABLE_SOURCE_CHANGES  ON)

--- a/cmake/SetupHomebrew.cmake
+++ b/cmake/SetupHomebrew.cmake
@@ -1,0 +1,58 @@
+#
+# SetupHomebrew.cmake - Add Homebrew prefix to CMAKE_PREFIX_PATH on macOS
+#
+# SPDX-FileCopyrightText: Oleg Shparber, et al. <https://zealdocs.org>
+# SPDX-License-Identifier: MIT
+#
+# Makes Homebrew-installed dependencies discoverable via standard find_package()
+# without manual HINTS or per-call fallback path lookups.
+#
+
+function(setup_homebrew)
+    if(NOT APPLE)
+        return()
+    endif()
+
+    # If a vcpkg toolchain is active, defer to it — its triplet root drives search.
+    if(CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg")
+        return()
+    endif()
+
+    # Prefer `brew --prefix` (handles non-standard installs); fall back to
+    # the well-known paths per host architecture.
+    find_program(_brew_executable brew)
+    if(_brew_executable)
+        execute_process(
+            COMMAND "${_brew_executable}" --prefix
+            OUTPUT_VARIABLE _brew_prefix
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE _brew_rc
+        )
+        if(_brew_rc EQUAL 0 AND IS_DIRECTORY "${_brew_prefix}")
+            set(_homebrew_prefix "${_brew_prefix}")
+        endif()
+    endif()
+
+    if(NOT _homebrew_prefix)
+        if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND IS_DIRECTORY "/opt/homebrew")
+            set(_homebrew_prefix "/opt/homebrew")
+        elseif(IS_DIRECTORY "/usr/local/Homebrew")
+            set(_homebrew_prefix "/usr/local")
+        endif()
+    endif()
+
+    if(NOT _homebrew_prefix)
+        return()
+    endif()
+
+    list(PREPEND CMAKE_PREFIX_PATH "${_homebrew_prefix}")
+
+    # libarchive is keg-only on Homebrew (macOS ships a stale version);
+    # add its prefix so find_package(LibArchive) finds it without manual hints.
+    if(IS_DIRECTORY "${_homebrew_prefix}/opt/libarchive")
+        list(PREPEND CMAKE_PREFIX_PATH "${_homebrew_prefix}/opt/libarchive")
+    endif()
+
+    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}" PARENT_SCOPE)
+    message(NOTICE "Using Homebrew prefix ${_homebrew_prefix}")
+endfunction()

--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -20,44 +20,26 @@ target_link_libraries(Core PRIVATE
 
 zeal_attach_qt_pch(Core <QDir>)
 
-find_package(LibArchive QUIET)
-if(NOT LibArchive_FOUND)
-    find_path(LibArchive_INCLUDE_DIRS archive.h
-        PATHS /opt/homebrew/opt/libarchive/include /usr/local/opt/libarchive/include
-        REQUIRED
-    )
-    find_library(LibArchive_LIBRARIES
-        NAMES archive libarchive
-        PATHS /opt/homebrew/opt/libarchive/lib /usr/local/opt/libarchive/lib
-        REQUIRED
-        NO_DEFAULT_PATH
-    )
-endif()
-
-if(TARGET LibArchive::LibArchive)
-    target_link_libraries(Core PRIVATE LibArchive::LibArchive)
-else()
-    include_directories(${LibArchive_INCLUDE_DIRS})
-    target_link_libraries(Core PRIVATE ${LibArchive_LIBRARIES})
-endif()
+find_package(LibArchive REQUIRED)
+target_link_libraries(Core PRIVATE LibArchive::LibArchive)
 
 # Configure toml++ (header-only).
-find_package(tomlplusplus CONFIG QUIET)
+find_package(tomlplusplus CONFIG)
 if(tomlplusplus_FOUND)
     target_link_libraries(Core PRIVATE tomlplusplus::tomlplusplus)
 else()
-    # Use bundled version of toml++ if not found.
+    message(STATUS "Using bundled tomlplusplus")
     target_include_directories(Core PRIVATE "${CMAKE_SOURCE_DIR}/src/contrib/tomlplusplus")
 endif()
 
 # Configure cpp-httplib.
 add_definitions(-DCPPHTTPLIB_USE_POLL)
 
-find_package(httplib CONFIG QUIET)
+find_package(httplib CONFIG)
 if(httplib_FOUND)
     target_link_libraries(Core PRIVATE httplib::httplib)
 else()
-    # Use bundled version of cpp-httplib if not found.
+    message(STATUS "Using bundled cpp-httplib")
     include_directories("${CMAKE_SOURCE_DIR}/src/contrib/cpp-httplib")
 endif()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build system with enhanced Homebrew package management to better locate and configure dependencies automatically during builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->