### PR TITLE
ci(github): add AUR publishing for zeal-git

### DIFF
--- a/.github/workflows/publish-aur.yaml
+++ b/.github/workflows/publish-aur.yaml
@@ -1,0 +1,50 @@
+name: Publish AUR Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish
+    if: github.repository == 'zealdocs/zeal'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # zeal-git tracks main HEAD; full history + tags are needed for git describe.
+          ref: main
+          fetch-depth: 0
+
+      - name: Compute package version
+        id: pkgver
+        # Mirror the PKGBUILD's pkgver() against main HEAD. The action computes the same
+        # value internally for .SRCINFO but commits before exposing it as an output.
+        run: |
+          version=$(git describe --long | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Publish zeal-git to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4
+        with:
+          pkgname: zeal-git
+          pkgbuild: pkg/aur/PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          ssh_keyscan_types: rsa,ecdsa,ed25519
+          commit_message: "Update to v${{ steps.pkgver.outputs.version }}"
+          # zeal-git is a VCS package: makepkg --printsrcinfo alone does not run
+          # pkgver(), so a --nobuild pass is required to refresh the version in the
+          # committed PKGBUILD and .SRCINFO. --nodeps skips installing build deps.
+          test: true
+          test_flags: --nobuild --nodeps

--- a/pkg/aur/PKGBUILD
+++ b/pkg/aur/PKGBUILD
@@ -1,0 +1,64 @@
+# Maintainer: Oleg Shparber <oleg@zealdocs.org>
+
+_appname=zeal
+
+pkgname=${_appname}-git
+pkgver=0.0.0
+pkgrel=1
+pkgdesc='Offline documentation browser'
+arch=(aarch64 i686 x86_64)
+url="https://zealdocs.org/"
+license=(GPL-3.0-or-later)
+depends=(
+  gcc-libs
+  glibc
+  hicolor-icon-theme
+  libarchive
+  libgcc
+  libstdc++
+  libx11
+  libxcb
+  qt6-base
+  qt6-svg
+  qt6-webchannel
+  qt6-webengine
+  sqlite
+  xcb-util-keysyms
+)
+makedepends=(
+  cmake
+  extra-cmake-modules
+  git
+  ninja
+  tomlplusplus
+  vulkan-headers
+)
+provides=(${_appname})
+conflicts=(${_appname})
+source=("${_appname}::git+https://github.com/zealdocs/${_appname}#branch=main")
+sha1sums=(SKIP)
+
+pkgver() {
+  cd ${_appname}
+
+  git describe --long | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  local cmake_options=(
+    -G Ninja
+    -B build
+    -S "$_appname"
+    -W no-dev
+    -D CMAKE_BUILD_TYPE=Release
+    -D CMAKE_INSTALL_PREFIX=/usr
+  )
+
+  cmake "${cmake_options[@]}"
+
+  cmake --build build
+}
+
+package() {
+  cmake --install build --prefix "${pkgdir}/usr"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated publishing to the Arch User Repository (AUR) on releases and manual triggers.
  * Included an AUR package build script so Arch Linux users can install and update via their package manager.
  * Package publishing now refreshes package metadata from the repository and commits updated package metadata automatically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->