### PR TITLE
ci(github): add windows arm64 builds via qvm

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -78,7 +78,6 @@ jobs:
         config:
           - name: Windows Server 2022
             os: windows-2022
-            arch: win64_msvc2022_64
             qt_modules: >-
               qtpositioning
               qtwebchannel
@@ -89,7 +88,26 @@ jobs:
             publishArtifacts: true
           - name: Windows Server 2022 Portable
             os: windows-2022
-            arch: win64_msvc2022_64
+            qt_modules: >-
+              qtpositioning
+              qtwebchannel
+              qtwebengine
+            qt_version: "6.10.2"
+            configurePreset: release-portable
+            buildPreset: release-portable
+            publishArtifacts: true
+          - name: Windows 11 ARM64
+            os: windows-11-arm
+            qt_modules: >-
+              qtpositioning
+              qtwebchannel
+              qtwebengine
+            qt_version: "6.10.2"
+            configurePreset: release
+            buildPreset: release
+            publishArtifacts: true
+          - name: Windows 11 ARM64 Portable
+            os: windows-11-arm
             qt_modules: >-
               qtpositioning
               qtwebchannel
@@ -133,12 +151,14 @@ jobs:
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          arch: ${{ matrix.config.arch }}
-          modules: ${{ matrix.config.qt_modules }}
-          version: ${{ matrix.config.qt_version }}
-          cache: true
+        run: |
+          $arch = if ("${{ runner.arch }}" -eq "ARM64") { "arm64" } else { "amd64" }
+          $qvm = "$env:RUNNER_TEMP\qvm.exe"
+          Invoke-WebRequest "https://github.com/trollixx/qvm/releases/latest/download/qvm-$arch.exe" -OutFile $qvm
+          & $qvm config set install.dir ${{ runner.workspace }}/qt
+          $modules = "${{ matrix.config.qt_modules }}".Trim() -replace '\s+', ','
+          & $qvm install ${{ matrix.config.qt_version }} --modules $modules
+          "CMAKE_PREFIX_PATH=$(& $qvm prefix ${{ matrix.config.qt_version }})" >> $env:GITHUB_ENV
 
       - name: Configure & Build
         uses: lukka/run-cmake@v10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
         config:
           - name: Windows Server 2022
             os: windows-2022
-            arch: win64_msvc2022_64
             qt_modules: >-
               qtpositioning
               qtwebchannel
@@ -38,7 +37,6 @@ jobs:
             uploadPattern: "zeal-*-windows-x64.msi"
           - name: Windows Server 2022 / Portable
             os: windows-2022
-            arch: win64_msvc2022_64
             qt_modules: >-
               qtpositioning
               qtwebchannel
@@ -47,6 +45,26 @@ jobs:
             configurePreset: release-portable
             buildPreset: release-portable
             uploadPattern: "zeal-*-portable-windows-x64.*"
+          - name: Windows 11 ARM64
+            os: windows-11-arm
+            qt_modules: >-
+              qtpositioning
+              qtwebchannel
+              qtwebengine
+            qt_version: "6.10.2"
+            configurePreset: release
+            buildPreset: release
+            uploadPattern: "zeal-*-windows-arm64.msi"
+          - name: Windows 11 ARM64 / Portable
+            os: windows-11-arm
+            qt_modules: >-
+              qtpositioning
+              qtwebchannel
+              qtwebengine
+            qt_version: "6.10.2"
+            configurePreset: release-portable
+            buildPreset: release-portable
+            uploadPattern: "zeal-*-portable-windows-arm64.*"
 
     steps:
       - name: Checkout
@@ -60,12 +78,14 @@ jobs:
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          arch: ${{ matrix.config.arch }}
-          modules: ${{ matrix.config.qt_modules }}
-          version: ${{ matrix.config.qt_version }}
-          cache: true
+        run: |
+          $arch = if ("${{ runner.arch }}" -eq "ARM64") { "arm64" } else { "amd64" }
+          $qvm = "$env:RUNNER_TEMP\qvm.exe"
+          Invoke-WebRequest "https://github.com/trollixx/qvm/releases/latest/download/qvm-$arch.exe" -OutFile $qvm
+          & $qvm config set install.dir ${{ runner.workspace }}/qt
+          $modules = "${{ matrix.config.qt_modules }}".Trim() -replace '\s+', ','
+          & $qvm install ${{ matrix.config.qt_version }} --modules $modules
+          "CMAKE_PREFIX_PATH=$(& $qvm prefix ${{ matrix.config.qt_version }})" >> $env:GITHUB_ENV
 
       - name: Configure & Build
         uses: lukka/run-cmake@v10
@@ -100,11 +120,12 @@ jobs:
           $dir = Join-Path $env:RUNNER_TEMP 'trusted-signing-client'
           New-Item -ItemType Directory -Force -Path $dir | Out-Null
           nuget install Microsoft.Trusted.Signing.Client -OutputDirectory $dir -ExcludeVersion
+          $arch = if ("${{ runner.arch }}" -eq "ARM64") { "arm64" } else { "x64" }
           $dlib = Get-ChildItem -Path $dir -Filter 'Azure.CodeSigning.Dlib.dll' -Recurse |
-              Where-Object { $_.FullName -match '[\\/]x64[\\/]' } |
+              Where-Object { $_.FullName -match "[\\/]$arch[\\/]" } |
               Select-Object -First 1 -ExpandProperty FullName
           if (-not $dlib) {
-              throw 'x64 Azure.CodeSigning.Dlib.dll not found in installed package.'
+              throw "$arch Azure.CodeSigning.Dlib.dll not found in installed package."
           }
           "CODESIGN_AZURE_DLIB=$dlib" >> $env:GITHUB_ENV
 

--- a/cmake/SetupVcpkg.cmake
+++ b/cmake/SetupVcpkg.cmake
@@ -48,19 +48,28 @@ function(setup_vcpkg)
         set(VCPKG_INSTALLED_DIR "${CMAKE_SOURCE_DIR}/build/vcpkg_installed" CACHE STRING "")
     endif()
 
-    # On Windows, default to a release-only triplet to speed up builds. Switch to the
-    # default (debug+release) triplet only for true Debug builds — RelWithDebInfo and
-    # MinSizeRel still link against release-built deps. Multi-config generators (Visual
-    # Studio, Ninja Multi-Config, Xcode) leave CMAKE_BUILD_TYPE empty at configure time,
-    # so default to the full triplet to cover every config the user may build.
+    # Match the triplet architecture to the host so native Windows-on-ARM builds link
+    # against arm64 deps instead of vcpkg's x64 default. PROCESSOR_ARCHITEW6432 covers an
+    # x86/x64 process running under emulation on an arm64 host.
     if(WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
-        get_cmake_property(_vcpkg_is_multi_config GENERATOR_IS_MULTI_CONFIG)
-        if(_vcpkg_is_multi_config OR CMAKE_BUILD_TYPE STREQUAL "Debug")
-            set(VCPKG_TARGET_TRIPLET "x64-windows" CACHE STRING "")
+        if("$ENV{PROCESSOR_ARCHITECTURE}" STREQUAL "ARM64" OR
+           "$ENV{PROCESSOR_ARCHITEW6432}" STREQUAL "ARM64")
+            # vcpkg ships no arm64-windows-release triplet, so use the full one.
+            set(VCPKG_TARGET_TRIPLET "arm64-windows" CACHE STRING "")
         else()
-            set(VCPKG_TARGET_TRIPLET "x64-windows-release" CACHE STRING "")
+            # On x64, default to a release-only triplet to speed up builds. Switch to the
+            # default (debug+release) triplet only for true Debug builds — RelWithDebInfo and
+            # MinSizeRel still link against release-built deps. Multi-config generators (Visual
+            # Studio, Ninja Multi-Config, Xcode) leave CMAKE_BUILD_TYPE empty at configure time,
+            # so default to the full triplet to cover every config the user may build.
+            get_cmake_property(_vcpkg_is_multi_config GENERATOR_IS_MULTI_CONFIG)
+            if(_vcpkg_is_multi_config OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+                set(VCPKG_TARGET_TRIPLET "x64-windows" CACHE STRING "")
+            else()
+                set(VCPKG_TARGET_TRIPLET "x64-windows-release" CACHE STRING "")
+            endif()
+            unset(_vcpkg_is_multi_config)
         endif()
-        unset(_vcpkg_is_multi_config)
     endif()
 
     # Deploy vcpkg dependencies alongside the build output.

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -155,6 +155,11 @@ if(WIN32)
     #   wix extension add --global WixToolset.UI.wixext/5.0.2
     #   wix extension add --global WixToolset.Util.wixext/5.0.2
     set(CPACK_WIX_VERSION "4")
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+        set(CPACK_WIX_ARCHITECTURE "x64")
+    else()
+        string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CPACK_WIX_ARCHITECTURE)
+    endif()
     set(CPACK_WIX_UPGRADE_GUID "5C4B6030-A1B4-4EFE-A5AF-28F6FA2E7978")
     set(CPACK_WIX_PROPERTY_ARPURLINFOABOUT ${CMAKE_PROJECT_HOMEPAGE_URL})
     set(CPACK_WIX_PRODUCT_ICON "${CMAKE_SOURCE_DIR}/src/app/resources/zeal.ico")


### PR DESCRIPTION
Using [qvm](https://github.com/trollixx/qvm) instead of aqtinstall.

Fixes #1411.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added official Windows 11 ARM64 and portable build targets.

* **Chores**
  * Updated CI to include ARM64 build variants and removed legacy per-matrix arch fields.
  * Made packaging/installer architecture-aware for correct ARM64/x64 labeling.
  * Improved build tool/dependency setup and signing steps to handle ARM64 runners and auto-select ARM64-targeted dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->