### PR TITLE
ci(github): use setup-qt action for Qt install

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -151,14 +151,10 @@ jobs:
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg
 
       - name: Install Qt
-        run: |
-          $arch = if ("${{ runner.arch }}" -eq "ARM64") { "arm64" } else { "amd64" }
-          $qvm = "$env:RUNNER_TEMP\qvm.exe"
-          Invoke-WebRequest "https://github.com/trollixx/qvm/releases/latest/download/qvm-$arch.exe" -OutFile $qvm
-          & $qvm config set install.dir ${{ runner.workspace }}/qt
-          $modules = "${{ matrix.config.qt_modules }}".Trim() -replace '\s+', ','
-          & $qvm install ${{ matrix.config.qt_version }} --modules $modules
-          "CMAKE_PREFIX_PATH=$(& $qvm prefix ${{ matrix.config.qt_version }})" >> $env:GITHUB_ENV
+        uses: trollixx/setup-qt@v1
+        with:
+          version: ${{ matrix.config.qt_version }}
+          modules: ${{ matrix.config.qt_modules }}
 
       - name: Configure & Build
         uses: lukka/run-cmake@v10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,14 +78,10 @@ jobs:
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg
 
       - name: Install Qt
-        run: |
-          $arch = if ("${{ runner.arch }}" -eq "ARM64") { "arm64" } else { "amd64" }
-          $qvm = "$env:RUNNER_TEMP\qvm.exe"
-          Invoke-WebRequest "https://github.com/trollixx/qvm/releases/latest/download/qvm-$arch.exe" -OutFile $qvm
-          & $qvm config set install.dir ${{ runner.workspace }}/qt
-          $modules = "${{ matrix.config.qt_modules }}".Trim() -replace '\s+', ','
-          & $qvm install ${{ matrix.config.qt_version }} --modules $modules
-          "CMAKE_PREFIX_PATH=$(& $qvm prefix ${{ matrix.config.qt_version }})" >> $env:GITHUB_ENV
+        uses: trollixx/setup-qt@v1
+        with:
+          version: ${{ matrix.config.qt_version }}
+          modules: ${{ matrix.config.qt_modules }}
 
       - name: Configure & Build
         uses: lukka/run-cmake@v10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Windows CI/CD workflows now use a standardized GitHub Action for Qt installation instead of custom PowerShell scripts in both build-check and release pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal/pull/1897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->