### PR TITLE
ci(github): replace libgl1-mesa-dev with libgl-dev

### DIFF
--- a/.github/workflows/analyze-codeql.yaml
+++ b/.github/workflows/analyze-codeql.yaml
@@ -45,7 +45,7 @@ jobs:
           cmake \
           extra-cmake-modules \
           libarchive-dev \
-          libgl1-mesa-dev \
+          libgl-dev \
           libqt6opengl6-dev \
           libqt6svg6-dev \
           libsqlite3-dev \

--- a/.github/workflows/analyze-coverity.yaml
+++ b/.github/workflows/analyze-coverity.yaml
@@ -30,7 +30,7 @@ jobs:
             extra-cmake-modules \
             git \
             libarchive-dev \
-            libgl1-mesa-dev \
+            libgl-dev \
             libqt6opengl6-dev \
             libqt6svg6-dev \
             libsqlite3-dev \

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -31,7 +31,7 @@ jobs:
           - name: Ubuntu 24.04
             os: ubuntu-24.04
             qt_packages: >-
-              libgl1-mesa-dev
+              libgl-dev
               libqt6opengl6-dev
               libqt6svg6-dev
               qt6-base-private-dev
@@ -42,7 +42,7 @@ jobs:
           - name: Ubuntu 24.04 ARM64
             os: ubuntu-24.04-arm
             qt_packages: >-
-              libgl1-mesa-dev
+              libgl-dev
               libqt6opengl6-dev
               libqt6svg6-dev
               qt6-base-private-dev
@@ -233,7 +233,7 @@ jobs:
             extra-cmake-modules \
             libarchive-dev \
             libfuse2t64 \
-            libgl1-mesa-dev \
+            libgl-dev \
             libqt6opengl6-dev \
             libqt6svg6-dev \
             libsqlite3-dev \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
             extra-cmake-modules \
             libarchive-dev \
             libfuse2t64 \
-            libgl1-mesa-dev \
+            libgl-dev \
             libqt6opengl6-dev \
             libqt6svg6-dev \
             libsqlite3-dev \
@@ -229,7 +229,7 @@ jobs:
           - name: Ubuntu 24.04 / Source
             os: ubuntu-24.04
             qt_packages: >-
-              libgl1-mesa-dev
+              libgl-dev
               libqt6opengl6-dev
               libqt6svg6-dev
               qt6-base-private-dev

--- a/pkg/snap/snapcraft.yaml
+++ b/pkg/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
     build-packages:
       - extra-cmake-modules
       - libarchive-dev
-      - libgl1-mesa-dev
+      - libgl-dev
       - libsqlite3-dev
       - libvulkan-dev
       - libxcb-keysyms1-dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenGL development library dependencies across CI/CD workflows and build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->