### PR TITLE
Add Copy-Selected operation to Zeal 

### DIFF
--- a/assets/tabler/edit-copy.svg
+++ b/assets/tabler/edit-copy.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m7 18.33a2.667 2.667 0 0 0 2.667 2.667h8.666a2.667 2.667 0 0 0 2.667-2.667v-8.666a2.667 2.667 0 0 0-2.667-2.667h-8.666a2.667 2.667 0 0 0-2.667 2.667v8.666"/>
+ <path d="m4.012 16.737a2.005 2.005 0 0 1-1.012-1.737v-10c0-1.1 0.9-2 2-2h10c0.75 0 1.158 0.385 1.5 1"/>
+ <path d="m11 13.997h6"/>
+ <path d="m14 10.997v6"/>
+</svg>

--- a/src/app/zeal.qrc
+++ b/src/app/zeal.qrc
@@ -14,6 +14,7 @@
         <file alias="arrow-left.svg">../../assets/tabler/arrow-left.svg</file>
         <file alias="arrow-right.svg">../../assets/tabler/arrow-right.svg</file>
         <file alias="dots-vertical.svg">../../assets/tabler/dots-vertical.svg</file>
+        <file alias="edit-copy.svg">../../assets/tabler/edit-copy.svg</file>
         <file alias="info-circle.svg">../../assets/tabler/info-circle.svg</file>
         <file alias="library.svg">../../assets/tabler/library.svg</file>
         <file alias="loader-2.svg">../../assets/tabler/loader-2.svg</file>

--- a/src/libs/browser/webcontrol.cpp
+++ b/src/libs/browser/webcontrol.cpp
@@ -142,6 +142,11 @@ void WebControl::resetZoom()
     m_webView->resetZoom();
 }
 
+void WebControl::copySelection()
+{
+    m_webView->copySelection();
+}
+
 void WebControl::setJavaScriptEnabled(bool enabled)
 {
     m_webView->page()->settings()->setAttribute(QWebEngineSettings::JavascriptEnabled, enabled);

--- a/src/libs/browser/webcontrol.h
+++ b/src/libs/browser/webcontrol.h
@@ -49,6 +49,7 @@ public:
     void zoomIn();
     void zoomOut();
     void resetZoom();
+    void copySelection();
 
 signals:
     void titleChanged(const QString &title);

--- a/src/libs/browser/webview.cpp
+++ b/src/libs/browser/webview.cpp
@@ -88,6 +88,11 @@ void WebView::resetZoom()
     setZoomLevel(defaultZoomLevel());
 }
 
+void WebView::copySelection()
+{
+    triggerPageAction(QWebEnginePage::Copy);
+}
+
 QWebEngineView *WebView::createWindow(QWebEnginePage::WebWindowType type)
 {
     auto *mw = qobject_cast<WidgetUi::MainWindow *>(window());

--- a/src/libs/browser/webview.h
+++ b/src/libs/browser/webview.h
@@ -29,6 +29,7 @@ public:
     void zoomIn();
     void zoomOut();
     void resetZoom();
+    void copySelection();
 
 signals:
     void zoomLevelChanged();

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -352,6 +352,17 @@ void MainWindow::setupMainMenu()
         }
     });
 
+    action = menu->addAction(IconHelper::fromTheme(QStringLiteral("edit-copy"),
+                                                   QStringLiteral(":/icons/tabler/edit-copy.svg")),
+                             tr("&Copy Selection"));
+    addAction(action);
+    action->setShortcut(QKeySequence(QStringLiteral("Ctrl+C")));
+    connect(action, &QAction::triggered, this, [this]() {
+        if (auto tab = currentTab()) {
+            tab->webControl()->copySelection();
+        }
+    });
+
     menu->addSeparator();
 
     // -> Preferences Action.


### PR DESCRIPTION
Add a simple Copy-Selection to Edit menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy Selection" action to the Edit menu with Ctrl+C keyboard shortcut for copying selected web content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->