### PR TITLE
feat(docsets): support compressed tarix docsets

### DIFF
--- a/src/libs/core/extractor.cpp
+++ b/src/libs/core/extractor.cpp
@@ -3,6 +3,8 @@
 
 #include "extractor.h"
 
+#include <util/tarixarchive.h>
+
 #include <QDir>
 #include <QLoggingCategory>
 #include <QThread>
@@ -31,6 +33,64 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
         return;
     }
 
+    if (extractEntries(sourceFile, destination, root, QString())) {
+        emit completed(sourceFile);
+    }
+}
+
+// Installs a docset that serves documents directly from its tarix archive:
+// only metadata entries are extracted, while the archive and its index are
+// placed under Contents/Resources for on-demand reads.
+void Extractor::installTarixDocset(const QString &sourceFile,
+                                   const QString &indexArchiveFile,
+                                   const QString &destination,
+                                   const QString &root)
+{
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, [this, sourceFile, indexArchiveFile, destination, root] {
+            installTarixDocset(sourceFile, indexArchiveFile, destination, root);
+        }, Qt::QueuedConnection);
+        return;
+    }
+
+    const QDir docsetDir(QDir(destination).filePath(root));
+    const QString indexPath = docsetDir.filePath(QStringLiteral("Contents/Resources/tarixIndex.db"));
+
+    bool usable = extractTarixIndex(indexArchiveFile, indexPath);
+    if (usable) {
+        // Read back a document so a stale or mismatched index falls back to extraction.
+        const Util::TarixArchive archive(sourceFile, indexPath);
+        usable = archive.isOpen() && archive.verify();
+    }
+
+    if (!usable) {
+        qCWarning(log, "Unusable tarix index for '%s', falling back to extraction.", qPrintable(sourceFile));
+        QFile::remove(indexPath);
+        extract(sourceFile, destination, root);
+        return;
+    }
+
+    if (!extractEntries(sourceFile, destination, root, QStringLiteral("Contents/Resources/Documents"))) {
+        QFile::remove(indexPath);
+        return;
+    }
+
+    const QString archivePath = docsetDir.filePath(QStringLiteral("Contents/Resources/tarix.tgz"));
+    if (!QFile::rename(sourceFile, archivePath) && !QFile::copy(sourceFile, archivePath)) {
+        emit error(sourceFile, tr("Failed to move archive to '%1'.").arg(archivePath));
+        return;
+    }
+
+    emit completed(sourceFile);
+}
+
+// Strips the leading directory in the archive; entries whose stripped path
+// starts with `skipPrefix` are not written to disk.
+bool Extractor::extractEntries(const QString &sourceFile,
+                               const QString &destination,
+                               const QString &root,
+                               const QString &skipPrefix)
+{
     ExtractInfo info = {.archiveHandle = archive_read_new(),
                         .filePath = sourceFile,
                         .totalBytes = QFileInfo(sourceFile).size(),
@@ -44,7 +104,7 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
         emit error(sourceFile, QString::fromLocal8Bit(archive_error_string(info.archiveHandle)));
         archive_read_free(info.archiveHandle);
 
-        return;
+        return false;
     }
 
     QDir destinationDir(destination);
@@ -63,6 +123,11 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
 
         if (!root.isEmpty()) {
             pathname.remove(0, pathname.indexOf(QLatin1String("/")) + 1);
+        }
+
+        // Unread entry data is skipped by the next header read.
+        if (!skipPrefix.isEmpty() && (pathname == skipPrefix || pathname.startsWith(skipPrefix + QLatin1Char('/')))) {
+            continue;
         }
 
         const QString filePath = destinationDir.absoluteFilePath(pathname);
@@ -103,7 +168,7 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
 
                 archive_read_free(info.archiveHandle);
 
-                return;
+                return false;
             }
 
             const auto toWrite = static_cast<qint64>(size);
@@ -112,15 +177,68 @@ void Extractor::extract(const QString &sourceFile, const QString &destination, c
                 qCWarning(log, "Cannot write extracted file data for '%s'.", qPrintable(pathname));
                 emit error(sourceFile, tr("Failed to write extracted file '%1'.").arg(pathname));
                 archive_read_free(info.archiveHandle);
-                return;
+                return false;
             }
         }
 
         emitProgress(info);
     }
 
-    emit completed(sourceFile);
     archive_read_free(info.archiveHandle);
+    return true;
+}
+
+bool Extractor::extractTarixIndex(const QString &indexArchiveFile, const QString &indexPath)
+{
+    archive *handle = archive_read_new();
+    archive_read_support_filter_all(handle);
+    archive_read_support_format_all(handle);
+
+    if (archive_read_open_filename(handle, qPrintable(indexArchiveFile), 10240) != ARCHIVE_OK) {
+        qCWarning(log, "Cannot open tarix index archive: %s.", archive_error_string(handle));
+        archive_read_free(handle);
+        return false;
+    }
+
+    bool success = false;
+
+    archive_entry *entry = nullptr;
+    while (archive_read_next_header(handle, &entry) == ARCHIVE_OK) {
+        if (archive_entry_filetype(entry) != S_IFREG) {
+            continue;
+        }
+
+        QDir().mkpath(QFileInfo(indexPath).absolutePath());
+
+        QFile file(indexPath);
+        if (!file.open(QIODevice::WriteOnly)) {
+            qCWarning(log, "Cannot open tarix index for writing at '%s'.", qPrintable(indexPath));
+            break;
+        }
+
+        const void *buffer = nullptr;
+        size_t size = 0;
+        std::int64_t offset = 0;
+        for (;;) {
+            const int rc = archive_read_data_block(handle, &buffer, &size, &offset);
+            if (rc == ARCHIVE_EOF) {
+                success = true;
+                break;
+            }
+
+            if (rc != ARCHIVE_OK
+                || file.write(static_cast<const char *>(buffer), static_cast<qint64>(size))
+                       != static_cast<qint64>(size)) {
+                qCWarning(log, "Cannot extract tarix index: %s.", archive_error_string(handle));
+                break;
+            }
+        }
+
+        break; // The archive contains a single index file.
+    }
+
+    archive_read_free(handle);
+    return success;
 }
 
 void Extractor::emitProgress(ExtractInfo &info)

--- a/src/libs/core/extractor.h
+++ b/src/libs/core/extractor.h
@@ -19,6 +19,10 @@ public:
     ~Extractor() override = default;
 
     void extract(const QString &sourceFile, const QString &destination, const QString &root = QString());
+    void installTarixDocset(const QString &sourceFile,
+                            const QString &indexArchiveFile,
+                            const QString &destination,
+                            const QString &root);
 
 signals:
     void error(const QString &filePath, const QString &message);
@@ -33,6 +37,12 @@ private:
         qint64 totalBytes;
         qint64 extractedBytes;
     };
+
+    bool extractEntries(const QString &sourceFile,
+                        const QString &destination,
+                        const QString &root,
+                        const QString &skipPrefix);
+    static bool extractTarixIndex(const QString &indexArchiveFile, const QString &indexPath);
 
     void emitProgress(ExtractInfo &info);
 };

--- a/src/libs/core/httpserver.cpp
+++ b/src/libs/core/httpserver.cpp
@@ -7,6 +7,7 @@
 
 #include <QDir>
 #include <QLoggingCategory>
+#include <QMimeDatabase>
 #include <QReadLocker>
 #include <QRegularExpression>
 #include <QWriteLocker>
@@ -63,6 +64,44 @@ HttpServer::HttpServer(QObject *parent)
         res.set_content(html.toUtf8().data(), "text/html");
     });
 
+    // Content-provider mounts share one catch-all route because cpp-httplib
+    // cannot remove individual handlers. Directory mounts are served by
+    // cpp-httplib before this handler is reached.
+    // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape): false positive — cpp-httplib stores the handler by value.
+    m_server->Get("/.+", [this](const auto &req, auto &res) {
+        const QString reqPath = QString::fromStdString(req.path);
+        const qsizetype prefixEnd = reqPath.indexOf(QLatin1Char('/'), 1);
+        const QString prefix = prefixEnd < 0 ? reqPath : reqPath.first(prefixEnd);
+        QString path = prefixEnd < 0 ? QString() : reqPath.mid(prefixEnd + 1);
+
+        // Hold the lock while reading so unmount cannot invalidate the provider mid-request.
+        const QReadLocker locker(&m_mountPointsLock);
+        const auto it = m_contentProviders.constFind(prefix);
+        if (it == m_contentProviders.constEnd()) {
+            res.status = 404;
+            return;
+        }
+
+        if (path.isEmpty() || path.endsWith(QLatin1Char('/'))) {
+            path += QLatin1String("index.html");
+        }
+
+        const std::optional<QByteArray> content = (*it)(path);
+        if (!content) {
+            res.status = 404;
+            return;
+        }
+
+        // Extension-less docset pages are HTML.
+        std::string mimeType = "text/html";
+        const QString fileName = path.mid(path.lastIndexOf(QLatin1Char('/')) + 1);
+        if (fileName.contains(QLatin1Char('.'))) {
+            mimeType = QMimeDatabase().mimeTypeForFile(path, QMimeDatabase::MatchExtension).name().toStdString();
+        }
+
+        res.set_content(content->constData(), content->size(), mimeType);
+    });
+
     m_future = std::async(std::launch::async, &httplib::Server::listen_after_bind, m_server.get());
 
     qCDebug(log, "Listening on %s...", qPrintable(m_baseUrl.toString()));
@@ -103,20 +142,43 @@ QUrl HttpServer::mount(const QString &prefix, const QString &path)
 
     qCDebug(log, "Mounted '%s' to '%s'.", qPrintable(path), qPrintable(pfx));
 
-    QUrl mountUrl = m_baseUrl;
-    mountUrl.setPath(m_baseUrl.path() + pfx);
-    return mountUrl;
+    return prefixUrl(pfx);
+}
+
+QUrl HttpServer::mount(const QString &prefix, ContentProvider provider)
+{
+    const QString pfx = sanitizePrefix(prefix);
+
+    {
+        const QWriteLocker locker(&m_mountPointsLock);
+        if (m_contentProviders.contains(pfx)) {
+            qCWarning(log, "Prefix '%s' is already mounted.", qPrintable(pfx));
+            return {};
+        }
+        m_contentProviders[pfx] = std::move(provider);
+    }
+
+    qCDebug(log, "Mounted content provider to '%s'.", qPrintable(pfx));
+
+    return prefixUrl(pfx);
 }
 
 bool HttpServer::unmount(const QString &prefix)
 {
     const QString pfx = sanitizePrefix(prefix);
-    const bool ok = m_server->remove_mount_point(pfx.toStdString());
-    if (!ok) {
-        qCWarning(log, "Failed to unmount '%s' to '%s'.", qPrintable(prefix), qPrintable(pfx));
+
+    bool ok = false;
+    {
+        const QWriteLocker locker(&m_mountPointsLock);
+        ok = m_contentProviders.remove(pfx);
     }
 
-    {
+    if (!ok) {
+        ok = m_server->remove_mount_point(pfx.toStdString());
+        if (!ok) {
+            qCWarning(log, "Failed to unmount '%s' to '%s'.", qPrintable(prefix), qPrintable(pfx));
+        }
+
         const QWriteLocker locker(&m_mountPointsLock);
         m_mountPoints.remove(pfx);
     }
@@ -158,6 +220,13 @@ QString HttpServer::resolvePathCaseInsensitive(const QString &root, const QStrin
     }
 
     return resolved;
+}
+
+QUrl HttpServer::prefixUrl(const QString &prefix) const
+{
+    QUrl url = m_baseUrl;
+    url.setPath(m_baseUrl.path() + prefix);
+    return url;
 }
 
 QString HttpServer::sanitizePrefix(const QString &prefix)

--- a/src/libs/core/httpserver.h
+++ b/src/libs/core/httpserver.h
@@ -4,13 +4,16 @@
 #ifndef ZEAL_CORE_HTTPSERVER_H
 #define ZEAL_CORE_HTTPSERVER_H
 
+#include <QByteArray>
 #include <QHash>
 #include <QObject>
 #include <QReadWriteLock>
 #include <QUrl>
 
+#include <functional>
 #include <future>
 #include <memory>
+#include <optional>
 
 namespace httplib {
 class Server;
@@ -23,15 +26,21 @@ class HttpServer : public QObject
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(HttpServer)
 public:
+    // Returns the file content for a mount-relative path, or nothing if absent.
+    using ContentProvider = std::function<std::optional<QByteArray>(const QString &path)>;
+
     explicit HttpServer(QObject *parent = nullptr);
     ~HttpServer() override;
 
     QUrl baseUrl() const;
 
     QUrl mount(const QString &prefix, const QString &path);
+    QUrl mount(const QString &prefix, ContentProvider provider);
     bool unmount(const QString &prefix);
 
 private:
+    QUrl prefixUrl(const QString &prefix) const;
+
     static QString sanitizePrefix(const QString &prefix);
     static QString resolvePathCaseInsensitive(const QString &root, const QString &path);
 
@@ -40,6 +49,7 @@ private:
     QUrl m_baseUrl;
     QReadWriteLock m_mountPointsLock;
     QHash<QString, QString> m_mountPoints;
+    QHash<QString, ContentProvider> m_contentProviders;
 
     // Must be last - its destructor blocks until the async thread completes,
     // ensuring the members above are still valid during shutdown.

--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -10,6 +10,7 @@
 #include <util/fuzzy.h>
 #include <util/plist.h>
 #include <util/statement.h>
+#include <util/tarixarchive.h>
 
 #include <QDir>
 #include <QFile>
@@ -34,6 +35,8 @@ using Qt::Literals::StringLiterals::operator""_L1;
 
 constexpr auto IndexNamePrefix = "__zi_name"_L1; // zi - Zeal index
 constexpr auto IndexNameVersion = "0001"_L1;     // Current index version
+
+constexpr auto DocumentsPath = "Contents/Resources/Documents/"_L1;
 
 constexpr auto NotFoundPageUrl = "qrc:///browser/404.html"_L1;
 
@@ -157,7 +160,18 @@ Docset::Docset(QString path)
         createView();
     }
 
-    if (!dir.cd(QStringLiteral("Documents"))) {
+    // Archived docsets keep documents in a tarix archive instead of a Documents directory.
+    if (dir.exists(QStringLiteral("tarix.tgz")) && dir.exists(QStringLiteral("tarixIndex.db"))) {
+        auto archive = std::make_unique<Util::TarixArchive>(dir.filePath(QStringLiteral("tarix.tgz")),
+                                                            dir.filePath(QStringLiteral("tarixIndex.db")));
+        if (!archive->isOpen()) {
+            qCWarning(log, "[%s] Cannot open tarix archive: %s.", qPrintable(m_name), qPrintable(archive->lastError()));
+            m_type = Type::Invalid;
+            return;
+        }
+
+        m_tarixArchive = std::move(archive);
+    } else if (!dir.cd(QStringLiteral("Documents"))) {
         qCWarning(log,
                   "[%s] Cannot change directory into 'Documents' at '%s'.",
                   qPrintable(m_name),
@@ -197,20 +211,24 @@ Docset::Docset(QString path)
     m_keywords.removeDuplicates();
 
     // Determine index page: prefer docset's plist, then metadata, then index.html.
+    const auto documentExists = [this, &dir](const QString &path) {
+        return m_tarixArchive != nullptr ? m_tarixArchive->exists(DocumentsPath + path) : dir.exists(path);
+    };
+
     QString indexFilePath;
 
     if (plist.contains(InfoPlist::DashIndexFilePath)) {
         const QString candidate = plist[InfoPlist::DashIndexFilePath].toString();
-        if (dir.exists(candidate)) {
+        if (documentExists(candidate)) {
             indexFilePath = candidate;
         }
     }
 
-    if (indexFilePath.isEmpty() && !m_indexFilePath.isEmpty() && dir.exists(m_indexFilePath)) {
+    if (indexFilePath.isEmpty() && !m_indexFilePath.isEmpty() && documentExists(m_indexFilePath)) {
         indexFilePath = m_indexFilePath;
     }
 
-    if (indexFilePath.isEmpty() && dir.exists(QStringLiteral("index.html"))) {
+    if (indexFilePath.isEmpty() && documentExists(QStringLiteral("index.html"))) {
         indexFilePath = QStringLiteral("index.html");
     }
 
@@ -275,6 +293,25 @@ QString Docset::path() const
 QString Docset::documentPath() const
 {
     return QDir(m_path).filePath(QStringLiteral("Contents/Resources/Documents"));
+}
+
+bool Docset::isArchived() const
+{
+    return m_tarixArchive != nullptr;
+}
+
+std::optional<QByteArray> Docset::readDocument(const QString &path) const
+{
+    if (m_tarixArchive == nullptr) {
+        return {};
+    }
+
+    QString relativePath = path;
+    while (relativePath.startsWith(QLatin1Char('/'))) {
+        relativePath.remove(0, 1);
+    }
+
+    return m_tarixArchive->read(DocumentsPath + relativePath);
 }
 
 QIcon Docset::icon() const

--- a/src/libs/registry/docset.h
+++ b/src/libs/registry/docset.h
@@ -13,12 +13,15 @@
 #include <QUrl>
 
 #include <atomic>
+#include <memory>
+#include <optional>
 #include <utility>
 
 namespace Zeal {
 
 namespace Util {
 class Database;
+class TarixArchive;
 } // namespace Util
 
 namespace Registry {
@@ -44,6 +47,10 @@ public:
 
     QString path() const;
     QString documentPath() const;
+
+    bool isArchived() const;
+    std::optional<QByteArray> readDocument(const QString &path) const;
+
     QIcon icon() const;
     static QIcon symbolTypeIcon(const QString &symbolType);
     QUrl indexFileUrl() const;
@@ -101,6 +108,7 @@ private:
     QMap<QString, int> m_symbolCounts;
     mutable QMap<QString, QList<std::pair<QString, QUrl>>> m_symbols;
     Util::Database *m_db = nullptr;
+    std::unique_ptr<Util::TarixArchive> m_tarixArchive;
 
     bool m_isFuzzySearchEnabled = false;
     bool m_isJavaScriptEnabled = false;

--- a/src/libs/registry/docsetmetadata.cpp
+++ b/src/libs/registry/docsetmetadata.cpp
@@ -43,6 +43,8 @@ DocsetMetadata::DocsetMetadata(const QJsonObject &jsonObject)
     // for comparison to work properly.
     m_revision = jsonObject[QStringLiteral("revision")].toString().toInt();
 
+    m_hasTarix = jsonObject[QStringLiteral("tarix")].toBool();
+
     m_feedUrl = QUrl(jsonObject[QStringLiteral("feed_url")].toString());
 
     const QJsonArray urls = jsonObject[QStringLiteral("urls")].toArray();
@@ -150,6 +152,11 @@ QString DocsetMetadata::latestVersion() const
 int DocsetMetadata::revision() const
 {
     return m_revision;
+}
+
+bool DocsetMetadata::hasTarix() const
+{
+    return m_hasTarix;
 }
 
 QUrl DocsetMetadata::feedUrl() const

--- a/src/libs/registry/docsetmetadata.h
+++ b/src/libs/registry/docsetmetadata.h
@@ -27,6 +27,7 @@ public:
     QString latestVersion() const;
     int revision() const;
     QIcon icon() const;
+    bool hasTarix() const;
 
     QUrl feedUrl() const;
     QUrl url() const;
@@ -40,6 +41,7 @@ private:
     QStringList m_aliases;
     QStringList m_versions;
     int m_revision = 0;
+    bool m_hasTarix = false;
 
     QByteArray m_rawIcon;
     QByteArray m_rawIcon2x;

--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -63,6 +63,13 @@ DocsetRegistry::~DocsetRegistry()
 {
     m_thread->exit();
     m_thread->wait();
+
+    // Unmount before deleting so the still-running HTTP server cannot invoke a
+    // content provider that captured a docset being destroyed.
+    const auto names = m_docsets.keys();
+    for (const QString &name : names) {
+        m_httpServer->unmount(name);
+    }
     qDeleteAll(m_docsets);
 }
 
@@ -162,7 +169,14 @@ void DocsetRegistry::registerDocset(Docset *docset)
     }
 
     // Setup HTTP mount.
-    const QUrl url = m_httpServer->mount(name, docset->documentPath());
+    QUrl url;
+    if (docset->isArchived()) {
+        url = m_httpServer->mount(name, [docset](const QString &path) {
+            return docset->readDocument(path);
+        });
+    } else {
+        url = m_httpServer->mount(name, docset->documentPath());
+    }
     if (url.isEmpty()) {
         qCWarning(log,
                   "Could not enable docset '%s' from '%s'. Reinstall the docset.",

--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -28,6 +28,7 @@
 #include <QMessageBox>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QPushButton>
 #include <QTemporaryFile>
 #include <QUrl>
 
@@ -44,7 +45,8 @@ using Qt::Literals::StringLiterals::operator""_L1;
 enum class DownloadType {
     DashFeed,
     Docset,
-    DocsetList
+    DocsetList,
+    TarixIndex
 };
 
 constexpr auto ApiServerUrl = "https://api.zealdocs.org/v1"_L1;
@@ -62,6 +64,9 @@ constexpr qint64 DownloadChunkSize = 1024LL * 1024; // 1 MiB
 constexpr const char *DocsetNameProperty = "docsetName";
 constexpr const char *DownloadTypeProperty = "downloadType";
 constexpr const char *ListItemIndexProperty = "listItem";
+constexpr const char *TarixRetryProperty = "tarixRetry";
+
+constexpr int MaxTarixIndexRetries = 2;
 
 void setDownloadType(QNetworkReply *reply, DownloadType type)
 {
@@ -267,6 +272,15 @@ void DocsetsDialog::downloadCompleted()
     m_replies.removeOne(reply.data());
 
     if (reply->error() != QNetworkReply::NoError) {
+        if (downloadType(reply.data()) == DownloadType::TarixIndex) {
+            if (reply->error() != QNetworkReply::OperationCanceledError) {
+                onTarixIndexFailed(reply.data());
+            }
+
+            updateStatus();
+            return;
+        }
+
         if (reply->error() != QNetworkReply::OperationCanceledError) {
             const QString msg = tr("Download failed!<br><br><b>Error:</b> %1<br><b>URL:</b> %2")
                                     .arg(reply->errorString(), reply->request().url().toString());
@@ -367,9 +381,52 @@ void DocsetsDialog::downloadCompleted()
             item->setData(DocsetListItemDelegate::FormatRole, tr("Installing: %p%"));
         }
 
-        m_application->extractor()->extract(tmpFile->fileName(),
-                                            m_application->settings()->docsetPath,
-                                            docsetDirectoryName);
+        const Registry::DocsetMetadata metadata = m_availableDocsets.contains(docsetName)
+                                                    ? m_availableDocsets[docsetName]
+                                                    : m_userFeeds[docsetName];
+
+        // A tarix index lets Zeal serve documents from the archive without extraction.
+        if (metadata.hasTarix()) {
+            QUrl indexUrl = reply->url();
+            indexUrl.setPath(indexUrl.path() + QLatin1String(".tarix"));
+            downloadTarixIndex(docsetName, indexUrl, 0);
+        } else {
+            installDownloadedDocset(docsetName);
+        }
+
+        break;
+    }
+
+    case DownloadType::TarixIndex: {
+        const QString docsetName = reply->property(DocsetNameProperty).toString();
+        const QString docsetDirectoryName = docsetName + QLatin1String(".docset");
+
+        QTemporaryFile *tmpFile = m_tmpFiles.value(docsetName);
+        if (tmpFile == nullptr) {
+            break; // Installation has been canceled.
+        }
+
+        const QByteArray indexData = reply->readAll();
+
+        // Some mirrors soft-404 with an HTML page; verify the gzip signature.
+        if (indexData.startsWith(QByteArrayLiteral("\x1f\x8b"))) {
+            auto *indexFile = new QTemporaryFile(QStringLiteral("%1/%2.tarix.XXXXXX.tmp")
+                                                     .arg(Core::Application::cacheLocation(), docsetName),
+                                                 this);
+            if (indexFile->open() && indexFile->write(indexData) == indexData.size()) {
+                indexFile->close();
+                m_tarixIndexFiles.insert(docsetName, indexFile);
+                m_application->extractor()->installTarixDocset(tmpFile->fileName(),
+                                                               indexFile->fileName(),
+                                                               m_application->settings()->docsetPath,
+                                                               docsetDirectoryName);
+                break;
+            }
+
+            delete indexFile;
+        }
+
+        installDownloadedDocset(docsetName);
         break;
     }
 
@@ -440,6 +497,7 @@ void DocsetsDialog::extractionCompleted(const QString &filePath)
     }
 
     delete m_tmpFiles.take(docsetName);
+    delete m_tarixIndexFiles.take(docsetName);
 
     updateStatus();
 }
@@ -458,6 +516,7 @@ void DocsetsDialog::extractionError(const QString &filePath, const QString &erro
     }
 
     delete m_tmpFiles.take(docsetName);
+    delete m_tarixIndexFiles.take(docsetName);
 }
 
 void DocsetsDialog::extractionProgress(const QString &filePath, qint64 extracted, qint64 total)
@@ -759,7 +818,8 @@ void DocsetsDialog::cancelDownloads()
             listItem->setData(DocsetListItemDelegate::ShowProgressRole, false);
         }
 
-        if (downloadType(reply) == DownloadType::Docset) {
+        const DownloadType type = downloadType(reply);
+        if (type == DownloadType::Docset || type == DownloadType::TarixIndex) {
             delete m_tmpFiles.take(reply->property(DocsetNameProperty).toString());
         }
 
@@ -909,6 +969,64 @@ void DocsetsDialog::downloadDashDocset(const QModelIndex &index)
     reply->setProperty(DocsetNameProperty, name);
     setDownloadType(reply, DownloadType::Docset);
     reply->setProperty(ListItemIndexProperty, ui->availableDocsetList->row(findDocsetListItem(name)));
+}
+
+void DocsetsDialog::downloadTarixIndex(const QString &docsetName, const QUrl &indexUrl, int attempt)
+{
+    QNetworkReply *reply = download(indexUrl);
+    reply->setProperty(DocsetNameProperty, docsetName);
+    reply->setProperty(TarixRetryProperty, attempt);
+    reply->setProperty(ListItemIndexProperty, ui->availableDocsetList->row(findDocsetListItem(docsetName)));
+    setDownloadType(reply, DownloadType::TarixIndex);
+}
+
+void DocsetsDialog::onTarixIndexFailed(QNetworkReply *reply)
+{
+    const QString docsetName = reply->property(DocsetNameProperty).toString();
+    const QUrl indexUrl = reply->request().url();
+    const int attempt = reply->property(TarixRetryProperty).toInt();
+
+    if (attempt < MaxTarixIndexRetries) {
+        downloadTarixIndex(docsetName, indexUrl, attempt + 1);
+        return;
+    }
+
+    QMessageBox box(QMessageBox::Warning,
+                    QStringLiteral("Zeal"),
+                    tr("Could not download the compact index for <b>%1</b>. Installing without it will be "
+                       "slower and use considerably more disk space.")
+                        .arg(docsetName),
+                    QMessageBox::NoButton,
+                    this);
+    QPushButton *retryButton = box.addButton(QMessageBox::Retry);
+    QPushButton *installButton = box.addButton(tr("Install Anyway"), QMessageBox::AcceptRole);
+    box.addButton(QMessageBox::Cancel);
+    box.setDefaultButton(retryButton);
+    box.exec();
+
+    if (box.clickedButton() == retryButton) {
+        downloadTarixIndex(docsetName, indexUrl, 0);
+    } else if (box.clickedButton() == installButton) {
+        installDownloadedDocset(docsetName);
+    } else {
+        QListWidgetItem *listItem = findDocsetListItem(docsetName);
+        if (listItem != nullptr) {
+            listItem->setData(DocsetListItemDelegate::ShowProgressRole, false);
+        }
+        delete m_tmpFiles.take(docsetName);
+    }
+}
+
+void DocsetsDialog::installDownloadedDocset(const QString &docsetName)
+{
+    QTemporaryFile *tmpFile = m_tmpFiles.value(docsetName);
+    if (tmpFile == nullptr) {
+        return;
+    }
+
+    m_application->extractor()->extract(tmpFile->fileName(),
+                                        m_application->settings()->docsetPath,
+                                        docsetName + QLatin1String(".docset"));
 }
 
 void DocsetsDialog::removeDocset(const QString &name)

--- a/src/libs/ui/docsetsdialog.h
+++ b/src/libs/ui/docsetsdialog.h
@@ -77,6 +77,7 @@ private:
     QMap<QString, Registry::DocsetMetadata> m_userFeeds;
 
     QHash<QString, QTemporaryFile *> m_tmpFiles;
+    QHash<QString, QTemporaryFile *> m_tarixIndexFiles;
 
     void setupInstalledDocsetsTab();
     void setupAvailableDocsetsTab();
@@ -99,6 +100,9 @@ private:
     void updateDocsetListDownloadTimeLabel(const QDateTime &modifiedTime);
 
     void downloadDashDocset(const QModelIndex &index);
+    void downloadTarixIndex(const QString &docsetName, const QUrl &indexUrl, int attempt);
+    void onTarixIndexFailed(QNetworkReply *reply);
+    void installDownloadedDocset(const QString &docsetName);
     void removeDocset(const QString &name);
 
     void updateStatus();

--- a/src/libs/util/CMakeLists.txt
+++ b/src/libs/util/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(Util STATIC
     humanizer.cpp
     plist.cpp
     statement.cpp
+    tarixarchive.cpp
 
     # Show headers without .cpp in Qt Creator.
     caseinsensitivemap.h
@@ -22,6 +23,12 @@ target_link_libraries(Util PRIVATE SQLite3::SQLite3)
 
 # TODO: Do not export SQLite headers.
 target_include_directories(Util PUBLIC ${SQLite3_INCLUDE_DIRS})
+
+find_package(LibArchive REQUIRED)
+target_link_libraries(Util PRIVATE LibArchive::LibArchive)
+
+find_package(ZLIB REQUIRED)
+target_link_libraries(Util PRIVATE ZLIB::ZLIB)
 
 # Tests
 if(BUILD_TESTING)

--- a/src/libs/util/tarixarchive.cpp
+++ b/src/libs/util/tarixarchive.cpp
@@ -1,0 +1,226 @@
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "tarixarchive.h"
+
+#include "database.h"
+#include "statement.h"
+
+#include <QFile>
+
+#include <archive.h>
+#include <archive_entry.h>
+#include <zlib.h>
+
+#include <bit>
+
+namespace Zeal::Util {
+
+namespace {
+constexpr qint64 TarBlockSize = 512;
+constexpr qsizetype InflateChunkSize = static_cast<qsizetype>(64) * 1024;
+// Upper bound for a single record, guarding against corrupt index entries.
+constexpr qint64 MaxRecordSize = static_cast<qint64>(64) * 1024 * 1024;
+
+QByteArray inflateFrom(QFile &file, qint64 rawSize)
+{
+    z_stream zs = {};
+    if (inflateInit2(&zs, -MAX_WBITS) != Z_OK) {
+        return {};
+    }
+
+    QByteArray out(rawSize, Qt::Uninitialized);
+    QByteArray in(InflateChunkSize, Qt::Uninitialized);
+
+    // next_out is set once; zlib advances it as it fills the output buffer.
+    zs.next_out = std::bit_cast<Bytef *>(out.data());
+    zs.avail_out = static_cast<uInt>(rawSize);
+
+    int rc = Z_OK;
+    while (zs.avail_out > 0 && rc != Z_STREAM_END) {
+        const qint64 inSize = file.read(in.data(), in.size());
+        if (inSize <= 0) {
+            break;
+        }
+
+        zs.next_in = std::bit_cast<Bytef *>(in.data());
+        zs.avail_in = static_cast<uInt>(inSize);
+
+        while (zs.avail_in > 0 && zs.avail_out > 0) {
+            rc = inflate(&zs, Z_NO_FLUSH);
+            if (rc == Z_BUF_ERROR) {
+                break; // Needs more input.
+            }
+            if (rc != Z_OK && rc != Z_STREAM_END) {
+                inflateEnd(&zs);
+                return {};
+            }
+            if (rc == Z_STREAM_END) {
+                break;
+            }
+        }
+    }
+
+    inflateEnd(&zs);
+    out.truncate(static_cast<qsizetype>(rawSize) - zs.avail_out);
+    return out;
+}
+
+// libarchive transparently consumes any leading GNU long-name and PAX records,
+// so the first returned header is the actual file.
+std::optional<QByteArray> readTarEntry(const QByteArray &tar)
+{
+    struct archive *a = archive_read_new();
+    archive_read_support_format_tar(a);
+
+    if (archive_read_open_memory(a, tar.constData(), tar.size()) != ARCHIVE_OK) {
+        archive_read_free(a);
+        return {};
+    }
+
+    std::optional<QByteArray> result;
+
+    archive_entry *entry = nullptr;
+    if (archive_read_next_header(a, &entry) == ARCHIVE_OK && archive_entry_filetype(entry) == AE_IFREG) {
+        const auto size = static_cast<qint64>(archive_entry_size(entry));
+        if (size >= 0 && size < tar.size()) {
+            QByteArray content(size, Qt::Uninitialized);
+            if (archive_read_data(a, content.data(), content.size()) == size) {
+                result = std::move(content);
+            }
+        }
+    }
+
+    archive_read_free(a);
+    return result;
+}
+} // namespace
+
+TarixArchive::TarixArchive(const QString &archivePath, const QString &indexPath)
+    : m_archivePath(archivePath)
+{
+    if (!QFile::exists(archivePath)) {
+        m_lastError = QStringLiteral("Archive does not exist: %1").arg(archivePath);
+        return;
+    }
+
+    // Check upfront because opening a nonexistent path would create an empty database.
+    if (!QFile::exists(indexPath)) {
+        m_lastError = QStringLiteral("Index does not exist: %1").arg(indexPath);
+        return;
+    }
+
+    auto index = std::make_unique<Database>(indexPath);
+    if (!index->isOpen()) {
+        m_lastError = index->lastError();
+        return;
+    }
+
+    if (!index->tables().contains(QStringLiteral("tarindex"), Qt::CaseInsensitive)) {
+        m_lastError = QStringLiteral("Index has no 'tarindex' table: %1").arg(indexPath);
+        return;
+    }
+
+    // Index paths start with the archive's root directory, e.g.
+    // "Python.docset/Contents/...", while callers pass root-relative paths.
+    Statement stmt(*index, QStringLiteral("SELECT path FROM tarindex WHERE path LIKE '%.docset/%' LIMIT 1"));
+    if (stmt.step()) {
+        const QString path = stmt.value(0).toString();
+        const QLatin1String marker(".docset/");
+        const qsizetype pos = path.indexOf(marker);
+        if (pos >= 0) {
+            m_rootPrefix = path.first(pos + marker.size());
+        }
+    }
+
+    m_index = std::move(index);
+}
+
+TarixArchive::~TarixArchive() = default;
+
+bool TarixArchive::isOpen() const
+{
+    return m_index != nullptr;
+}
+
+QString TarixArchive::lastError() const
+{
+    return m_lastError;
+}
+
+bool TarixArchive::verify() const
+{
+    if (m_index == nullptr) {
+        return false;
+    }
+
+    QString storedPath;
+    {
+        const QMutexLocker locker(&m_indexMutex);
+        Statement stmt(*m_index, QStringLiteral("SELECT path FROM tarindex WHERE path LIKE ? AND hash <> '' LIMIT 1"));
+        stmt.bindText(1, QStringLiteral("%/Contents/Resources/Documents/%"));
+        if (stmt.step()) {
+            storedPath = stmt.value(0).toString();
+        }
+    }
+
+    return !storedPath.isEmpty() && readRecord(lookupHash(storedPath)).has_value();
+}
+
+bool TarixArchive::exists(const QString &path) const
+{
+    return !lookupHash(m_rootPrefix + path).isEmpty();
+}
+
+std::optional<QByteArray> TarixArchive::read(const QString &path) const
+{
+    return readRecord(lookupHash(m_rootPrefix + path));
+}
+
+std::optional<QByteArray> TarixArchive::readRecord(const QString &hash) const
+{
+    const QList<QByteArray> fields = hash.toLatin1().split(' ');
+    if (fields.size() != 3) {
+        return {};
+    }
+
+    bool offsetOk = false;
+    bool blockCountOk = false;
+    const qint64 offset = fields.at(1).toLongLong(&offsetOk);
+    const qint64 blockCount = fields.at(2).toLongLong(&blockCountOk);
+    if (!offsetOk || !blockCountOk || offset < 0 || blockCount < 1 || blockCount > MaxRecordSize / TarBlockSize) {
+        return {};
+    }
+
+    QFile archive(m_archivePath);
+    if (!archive.open(QIODevice::ReadOnly) || !archive.seek(offset)) {
+        return {};
+    }
+
+    const qint64 rawSize = blockCount * TarBlockSize;
+    const QByteArray tar = inflateFrom(archive, rawSize);
+    if (tar.size() != rawSize) {
+        return {};
+    }
+
+    return readTarEntry(tar);
+}
+
+QString TarixArchive::lookupHash(const QString &storedPath) const
+{
+    if (m_index == nullptr) {
+        return {};
+    }
+
+    const QMutexLocker locker(&m_indexMutex);
+
+    Statement stmt(*m_index, QStringLiteral("SELECT hash FROM tarindex WHERE path = ?"));
+    stmt.bindText(1, storedPath);
+    if (!stmt.step()) {
+        return {};
+    }
+
+    return stmt.value(0).toString();
+}
+
+} // namespace Zeal::Util

--- a/src/libs/util/tarixarchive.h
+++ b/src/libs/util/tarixarchive.h
@@ -1,0 +1,56 @@
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ZEAL_UTIL_TARIXARCHIVE_H
+#define ZEAL_UTIL_TARIXARCHIVE_H
+
+#include <QByteArray>
+#include <QMutex>
+#include <QString>
+
+#include <memory>
+#include <optional>
+
+namespace Zeal::Util {
+
+class Database;
+
+// Reads individual files from a tarix-compressed archive without unpacking it.
+// The archive is a regular .tgz created with a zlib full flush point before
+// every tar record, so decompression can start cold at any indexed offset.
+// The index database maps archive paths to "<block> <offset> <length>"
+// triples, where <offset> is the compressed byte offset of the flush point
+// and <length> is the record size in 512-byte tar blocks.
+class TarixArchive
+{
+    Q_DISABLE_COPY_MOVE(TarixArchive)
+public:
+    TarixArchive(const QString &archivePath, const QString &indexPath);
+    ~TarixArchive();
+
+    bool isOpen() const;
+    QString lastError() const;
+
+    // Reads one indexed document to confirm the index matches the archive.
+    bool verify() const;
+
+    // Paths are relative to the archive root directory,
+    // e.g. "Contents/Resources/Documents/index.html". Lookups are case-insensitive.
+    bool exists(const QString &path) const;
+    std::optional<QByteArray> read(const QString &path) const;
+
+private:
+    QString lookupHash(const QString &storedPath) const;
+    std::optional<QByteArray> readRecord(const QString &hash) const;
+
+    QString m_archivePath;
+    QString m_rootPrefix;
+    QString m_lastError;
+
+    mutable QMutex m_indexMutex;
+    std::unique_ptr<Database> m_index;
+};
+
+} // namespace Zeal::Util
+
+#endif // ZEAL_UTIL_TARIXARCHIVE_H

--- a/src/libs/util/tests/CMakeLists.txt
+++ b/src/libs/util/tests/CMakeLists.txt
@@ -11,3 +11,9 @@ add_executable(statement_test statement_test.cpp)
 target_link_libraries(statement_test PRIVATE Util Qt6::Test)
 
 zeal_add_test(statement_test)
+
+# Tarix archive tests
+add_executable(tarixarchive_test tarixarchive_test.cpp)
+target_link_libraries(tarixarchive_test PRIVATE Util Qt6::Test ZLIB::ZLIB)
+
+zeal_add_test(tarixarchive_test)

--- a/src/libs/util/tests/tarixarchive_test.cpp
+++ b/src/libs/util/tests/tarixarchive_test.cpp
@@ -1,0 +1,355 @@
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../database.h"
+#include "../statement.h"
+#include "../tarixarchive.h"
+
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include <zlib.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using namespace Zeal::Util;
+
+namespace {
+constexpr qsizetype TarBlockSize = 512;
+
+QByteArray tarHeader(const QByteArray &name, qint64 size, char typeflag)
+{
+    QByteArray header(TarBlockSize, '\0');
+    char *h = header.data();
+
+    std::memcpy(h, name.constData(), qMin<qsizetype>(name.size(), 100));
+    std::snprintf(h + 100, 8, "%07o", 0644u); // mode
+    std::snprintf(h + 108, 8, "%07o", 0u);    // uid
+    std::snprintf(h + 116, 8, "%07o", 0u);    // gid
+    std::snprintf(h + 124, 12, "%011llo", static_cast<unsigned long long>(size));
+    std::snprintf(h + 136, 12, "%011llo", 0ULL); // mtime
+    std::memset(h + 148, ' ', 8);                // chksum placeholder
+    h[156] = typeflag;
+    std::memcpy(h + 257, "ustar", 6); // magic
+    std::memcpy(h + 263, "00", 2);    // version
+
+    unsigned int checksum = 0;
+    for (qsizetype i = 0; i < TarBlockSize; ++i) {
+        checksum += static_cast<unsigned char>(header.at(i));
+    }
+    std::snprintf(h + 148, 8, "%06o", checksum);
+    h[155] = ' ';
+
+    return header;
+}
+
+QByteArray tarRecord(const QByteArray &name, const QByteArray &content)
+{
+    QByteArray record;
+
+    // GNU long name record for paths exceeding the 100-byte header field.
+    if (name.size() > 100) {
+        const QByteArray nameData = name + '\0';
+        record += tarHeader(QByteArrayLiteral("././@LongLink"), nameData.size(), 'L');
+        record += nameData;
+        record += QByteArray((TarBlockSize - nameData.size() % TarBlockSize) % TarBlockSize, '\0');
+    }
+
+    record += tarHeader(name.first(qMin<qsizetype>(name.size(), 100)), content.size(), '0');
+    record += content;
+    record += QByteArray((TarBlockSize - content.size() % TarBlockSize) % TarBlockSize, '\0');
+
+    return record;
+}
+
+// Writes a gzip archive with a zlib full flush point before every record and
+// returns "<block> <offset> <blockLength>" index hashes, mirroring tarix.
+class TarixWriter
+{
+public:
+    bool open(const QString &path)
+    {
+        m_file.setFileName(path);
+        if (!m_file.open(QIODevice::WriteOnly)) {
+            return false;
+        }
+
+        const int rc = deflateInit2(&m_zs, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+        if (rc != Z_OK) {
+            return false;
+        }
+
+        // Emit the gzip header and position the stream at a flush point.
+        deflateChunk({}, Z_FULL_FLUSH);
+        return true;
+    }
+
+    QString addRecord(const QByteArray &record)
+    {
+        const QString hash = QStringLiteral("%1 %2 %3")
+                                 .arg(m_rawPos / TarBlockSize)
+                                 .arg(m_zs.total_out)
+                                 .arg(record.size() / TarBlockSize);
+        deflateChunk(record, Z_FULL_FLUSH);
+        m_rawPos += record.size();
+        return hash;
+    }
+
+    void close()
+    {
+        deflateChunk(QByteArray(2 * TarBlockSize, '\0'), Z_FINISH);
+        deflateEnd(&m_zs);
+        m_file.close();
+    }
+
+private:
+    void deflateChunk(const QByteArray &data, int flush)
+    {
+        // zlib operates on Bytef (unsigned char), so use matching buffers to
+        // avoid char/unsigned-char punning.
+        std::vector<Bytef> in(data.cbegin(), data.cend());
+        m_zs.next_in = in.data();
+        m_zs.avail_in = static_cast<uInt>(in.size());
+
+        std::vector<Bytef> out(64 * 1024);
+        int rc = Z_OK;
+        do {
+            m_zs.next_out = out.data();
+            m_zs.avail_out = static_cast<uInt>(out.size());
+            rc = deflate(&m_zs, flush);
+
+            const qsizetype produced = static_cast<qsizetype>(out.size() - m_zs.avail_out);
+            QByteArray chunk(produced, Qt::Uninitialized);
+            std::copy_n(out.cbegin(), produced, chunk.begin());
+            m_file.write(chunk);
+        } while (m_zs.avail_out == 0 || m_zs.avail_in > 0 || (flush == Z_FINISH && rc != Z_STREAM_END));
+    }
+
+    QFile m_file;
+    z_stream m_zs = {};
+    qint64 m_rawPos = 0;
+};
+} // namespace
+
+class TarixArchiveTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+
+    void testMissingArchive();
+    void testMissingIndex();
+    void testIsOpen();
+    void testExists();
+    void testExistsCaseInsensitive();
+    void testReadContent();
+    void testReadEmptyFile();
+    void testReadLongName();
+    void testReadWindowsInvalidChars();
+    void testReadMissing();
+    void testReadRejectsBadHashFormats();
+    void testVerify();
+    void testVerifyWithoutDocuments();
+    void testVerifyDetectsStaleIndex();
+
+private:
+    QTemporaryDir m_dir;
+    QString m_archivePath;
+    QString m_indexPath;
+    QByteArray m_pageContent;
+    QString m_longName;
+};
+
+void TarixArchiveTest::initTestCase()
+{
+    QVERIFY(m_dir.isValid());
+    m_archivePath = m_dir.filePath(QStringLiteral("tarix.tgz"));
+    m_indexPath = m_dir.filePath(QStringLiteral("tarixIndex.db"));
+
+    // Compressible content spanning multiple tar blocks and inflate chunks.
+    m_pageContent = QByteArrayLiteral("<html><body>");
+    for (int i = 0; i < 20000; ++i) {
+        m_pageContent += QByteArrayLiteral("<p>paragraph ") + QByteArray::number(i) + QByteArrayLiteral("</p>\n");
+    }
+    m_pageContent += QByteArrayLiteral("</body></html>");
+
+    m_longName = QStringLiteral("Contents/Resources/Documents/") + QString(QLatin1Char('d')).repeated(120)
+               + QStringLiteral("/page.html");
+
+    TarixWriter writer;
+    QVERIFY(writer.open(m_archivePath));
+
+    const QByteArray root = QByteArrayLiteral("Test.docset/");
+    QStringList hashes;
+    hashes << writer.addRecord(tarRecord(root + "Contents/Resources/Documents/page.html", m_pageContent));
+    hashes << writer.addRecord(tarRecord(root + "Contents/Resources/Documents/empty.txt", {}));
+    hashes << writer.addRecord(tarRecord(root + m_longName.toUtf8(), QByteArrayLiteral("long name content")));
+    hashes << writer.addRecord(
+        tarRecord(root + "Contents/Resources/Documents/operator*.html", QByteArrayLiteral("star content")));
+    writer.close();
+
+    const QStringList paths = {QStringLiteral("Test.docset/Contents/Resources/Documents/page.html"),
+                               QStringLiteral("Test.docset/Contents/Resources/Documents/empty.txt"),
+                               QStringLiteral("Test.docset/") + m_longName,
+                               QStringLiteral("Test.docset/Contents/Resources/Documents/operator*.html")};
+
+    Database db(m_indexPath);
+    QVERIFY(db.isOpen());
+    QVERIFY(db.execute(QStringLiteral("CREATE TABLE tarindex(path TEXT PRIMARY KEY COLLATE NOCASE, hash TEXT)")));
+    for (qsizetype i = 0; i < paths.size(); ++i) {
+        Statement stmt(db, QStringLiteral("INSERT INTO tarindex VALUES(?, ?)"));
+        stmt.bindText(1, paths.at(i));
+        stmt.bindText(2, hashes.at(i));
+        QVERIFY(!stmt.step());
+        QVERIFY(stmt.lastError().isEmpty());
+    }
+}
+
+void TarixArchiveTest::testMissingArchive()
+{
+    const TarixArchive archive(m_dir.filePath(QStringLiteral("nonexistent.tgz")), m_indexPath);
+    QVERIFY(!archive.isOpen());
+    QVERIFY(!archive.lastError().isEmpty());
+}
+
+void TarixArchiveTest::testMissingIndex()
+{
+    const TarixArchive archive(m_archivePath, m_dir.filePath(QStringLiteral("nonexistent.db")));
+    QVERIFY(!archive.isOpen());
+}
+
+void TarixArchiveTest::testIsOpen()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    QVERIFY(archive.isOpen());
+    QVERIFY(archive.lastError().isEmpty());
+}
+
+void TarixArchiveTest::testExists()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    QVERIFY(archive.exists(QStringLiteral("Contents/Resources/Documents/page.html")));
+    QVERIFY(!archive.exists(QStringLiteral("Contents/Resources/Documents/missing.html")));
+}
+
+void TarixArchiveTest::testExistsCaseInsensitive()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    QVERIFY(archive.exists(QStringLiteral("contents/resources/documents/PAGE.HTML")));
+}
+
+void TarixArchiveTest::testReadContent()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    const auto content = archive.read(QStringLiteral("Contents/Resources/Documents/page.html"));
+    QVERIFY(content.has_value());
+    QCOMPARE(*content, m_pageContent);
+}
+
+void TarixArchiveTest::testReadEmptyFile()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    const auto content = archive.read(QStringLiteral("Contents/Resources/Documents/empty.txt"));
+    QVERIFY(content.has_value());
+    QVERIFY(content->isEmpty());
+}
+
+void TarixArchiveTest::testReadLongName()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    const auto content = archive.read(m_longName);
+    QVERIFY(content.has_value());
+    QCOMPARE(*content, QByteArrayLiteral("long name content"));
+}
+
+void TarixArchiveTest::testReadWindowsInvalidChars()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    const auto content = archive.read(QStringLiteral("Contents/Resources/Documents/operator*.html"));
+    QVERIFY(content.has_value());
+    QCOMPARE(*content, QByteArrayLiteral("star content"));
+}
+
+void TarixArchiveTest::testReadMissing()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    QVERIFY(!archive.read(QStringLiteral("Contents/Resources/Documents/missing.html")).has_value());
+}
+
+void TarixArchiveTest::testReadRejectsBadHashFormats()
+{
+    const QString badPath = m_dir.filePath(QStringLiteral("badhash.db"));
+    const QStringList badHashes = {QStringLiteral("garbage"),
+                                   QStringLiteral("0 5"),
+                                   QStringLiteral("x y z"),
+                                   QStringLiteral("0 -1 1"),
+                                   QStringLiteral("0 0 0"),
+                                   QStringLiteral("0 0 99999999")};
+    {
+        Database db(badPath);
+        QVERIFY(db.isOpen());
+        QVERIFY(db.execute(QStringLiteral("CREATE TABLE tarindex(path TEXT PRIMARY KEY COLLATE NOCASE, hash TEXT)")));
+        for (qsizetype i = 0; i < badHashes.size(); ++i) {
+            Statement stmt(db, QStringLiteral("INSERT INTO tarindex VALUES(?, ?)"));
+            stmt.bindText(1, QStringLiteral("Test.docset/Contents/Resources/Documents/bad%1.html").arg(i));
+            stmt.bindText(2, badHashes.at(i));
+            QVERIFY(!stmt.step());
+        }
+    }
+
+    const TarixArchive archive(m_archivePath, badPath);
+    QVERIFY(archive.isOpen());
+    for (qsizetype i = 0; i < badHashes.size(); ++i) {
+        QVERIFY(!archive.read(QStringLiteral("Contents/Resources/Documents/bad%1.html").arg(i)).has_value());
+    }
+}
+
+void TarixArchiveTest::testVerify()
+{
+    const TarixArchive archive(m_archivePath, m_indexPath);
+    QVERIFY(archive.verify());
+}
+
+void TarixArchiveTest::testVerifyWithoutDocuments()
+{
+    const QString metaOnlyPath = m_dir.filePath(QStringLiteral("metaonly.db"));
+    {
+        Database db(metaOnlyPath);
+        QVERIFY(db.isOpen());
+        QVERIFY(db.execute(QStringLiteral("CREATE TABLE tarindex(path TEXT PRIMARY KEY COLLATE NOCASE, hash TEXT)")));
+        Statement stmt(db, QStringLiteral("INSERT INTO tarindex VALUES(?, ?)"));
+        stmt.bindText(1, QStringLiteral("Test.docset/Contents/Resources/docSet.dsidx"));
+        stmt.bindText(2, QStringLiteral("0 0 1"));
+        QVERIFY(!stmt.step());
+    }
+
+    const TarixArchive archive(m_archivePath, metaOnlyPath);
+    QVERIFY(archive.isOpen());
+    QVERIFY(!archive.verify());
+}
+
+void TarixArchiveTest::testVerifyDetectsStaleIndex()
+{
+    // An index whose offset does not point at a flush point in the archive.
+    const QString stalePath = m_dir.filePath(QStringLiteral("stale.db"));
+    {
+        Database db(stalePath);
+        QVERIFY(db.isOpen());
+        QVERIFY(db.execute(QStringLiteral("CREATE TABLE tarindex(path TEXT PRIMARY KEY COLLATE NOCASE, hash TEXT)")));
+        Statement stmt(db, QStringLiteral("INSERT INTO tarindex VALUES(?, ?)"));
+        stmt.bindText(1, QStringLiteral("Test.docset/Contents/Resources/Documents/page.html"));
+        stmt.bindText(2, QStringLiteral("0 5 1"));
+        QVERIFY(!stmt.step());
+    }
+
+    const TarixArchive archive(m_archivePath, stalePath);
+    QVERIFY(archive.isOpen());
+    QVERIFY(!archive.verify());
+}
+
+QTEST_GUILESS_MAIN(TarixArchiveTest)
+#include "tarixarchive_test.moc"


### PR DESCRIPTION
Fixes #138.
Fixes #1278.
Fixes #1588.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install and serve archive-backed (Tarix) docsets with deferred extraction and on-demand archived document reads.
  * UI: download/retry flow for compact-index (.tarix) files with “Install Anyway” fallback.

* **Improvements**
  * HTTP server: callback-driven mounts with MIME detection and safer mount/unmount lifecycle.
  * Docset metadata: detect/report archived docsets; registry mounts archived docsets via per-request handlers.

* **Tests**
  * Comprehensive tests for archive/index handling, long paths, and integrity verification.

* **Chores**
  * Added LibArchive/Zlib support for archive processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->