### PR TITLE
fix: harden docset download and extraction

### DIFF
--- a/src/libs/core/extractor.cpp
+++ b/src/libs/core/extractor.cpp
@@ -115,9 +115,13 @@ bool Extractor::extractEntries(const QString &sourceFile,
     // Destination directory must be created before any other files.
     destinationDir.mkpath(QLatin1String("."));
 
+    const QString destinationRoot = destinationDir.absolutePath();
+    const QString destinationPrefix = destinationRoot.endsWith(QLatin1Char('/')) ? destinationRoot
+                                                                                 : destinationRoot + QLatin1Char('/');
+
     // TODO: Do not strip root directory in archive if it equals to 'root'
     archive_entry *entry = nullptr;
-    while (archive_read_next_header(info.archiveHandle, &entry) == ARCHIVE_OK) {
+    while ((rc = archive_read_next_header(info.archiveHandle, &entry)) == ARCHIVE_OK) {
         // See https://github.com/libarchive/libarchive/issues/587 for more on UTF-8.
         QString pathname = QString::fromUtf8(archive_entry_pathname_utf8(entry));
 
@@ -130,7 +134,14 @@ bool Extractor::extractEntries(const QString &sourceFile,
             continue;
         }
 
-        const QString filePath = destinationDir.absoluteFilePath(pathname);
+        // Reject entries that resolve outside the destination (path traversal).
+        const QString filePath = QDir::cleanPath(destinationDir.absoluteFilePath(pathname));
+        if (filePath != destinationRoot && !filePath.startsWith(destinationPrefix)) {
+            qCWarning(log, "Archive entry escapes destination: '%s'.", qPrintable(pathname));
+            emit error(sourceFile, tr("Archive entry '%1' escapes the destination directory.").arg(pathname));
+            archive_read_free(info.archiveHandle);
+            return false;
+        }
 
         const auto filetype = archive_entry_filetype(entry);
         if (filetype == S_IFDIR) {
@@ -182,6 +193,13 @@ bool Extractor::extractEntries(const QString &sourceFile,
         }
 
         emitProgress(info);
+    }
+
+    if (rc != ARCHIVE_EOF) {
+        qCWarning(log, "Cannot read from archive: %s.", archive_error_string(info.archiveHandle));
+        emit error(sourceFile, QString::fromLocal8Bit(archive_error_string(info.archiveHandle)));
+        archive_read_free(info.archiveHandle);
+        return false;
     }
 
     archive_read_free(info.archiveHandle);

--- a/src/libs/core/tests/CMakeLists.txt
+++ b/src/libs/core/tests/CMakeLists.txt
@@ -4,3 +4,11 @@ add_executable(session_test session_test.cpp)
 target_link_libraries(session_test PRIVATE Core Qt6::Test)
 
 zeal_add_test(session_test)
+
+add_executable(extractor_test extractor_test.cpp)
+target_link_libraries(extractor_test PRIVATE Core Qt6::Test)
+
+find_package(LibArchive REQUIRED)
+target_link_libraries(extractor_test PRIVATE LibArchive::LibArchive)
+
+zeal_add_test(extractor_test)

--- a/src/libs/core/tests/extractor_test.cpp
+++ b/src/libs/core/tests/extractor_test.cpp
@@ -1,0 +1,133 @@
+// Copyright (C) Oleg Shparber, et al. <https://zealdocs.org>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../extractor.h"
+
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include <archive.h>
+#include <archive_entry.h>
+
+using Zeal::Core::Extractor;
+
+namespace {
+struct Entry
+{
+    QByteArray path;
+    QByteArray content;
+};
+
+bool writeArchive(const QString &path, const QList<Entry> &entries, bool gzip = true)
+{
+    archive *a = archive_write_new();
+    if (gzip) {
+        archive_write_add_filter_gzip(a);
+    }
+    archive_write_set_format_ustar(a);
+
+    bool ok = archive_write_open_filename(a, path.toLocal8Bit().constData()) == ARCHIVE_OK;
+    for (const Entry &entry : entries) {
+        if (!ok) {
+            break;
+        }
+
+        archive_entry *e = archive_entry_new();
+        archive_entry_set_pathname(e, entry.path.constData());
+        archive_entry_set_size(e, entry.content.size());
+        archive_entry_set_filetype(e, AE_IFREG);
+        archive_entry_set_perm(e, 0644);
+        ok = archive_write_header(a, e) == ARCHIVE_OK
+          && archive_write_data(a, entry.content.constData(), entry.content.size()) >= 0;
+        archive_entry_free(e);
+    }
+
+    ok = (archive_write_close(a) == ARCHIVE_OK) && ok;
+    archive_write_free(a);
+    return ok;
+}
+} // namespace
+
+class ExtractorTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testExtractsRegularEntries();
+    void testRejectsPathTraversal();
+    void testRejectsTruncatedArchive();
+};
+
+void ExtractorTest::testExtractsRegularEntries()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    const QString archivePath = dir.filePath(QStringLiteral("docset.tgz"));
+    QVERIFY(writeArchive(archivePath,
+                         {{"Test.docset/Contents/Info.plist", "plist"},
+                          {"Test.docset/Contents/Resources/docSet.dsidx", "index"}}));
+
+    Extractor extractor;
+    QSignalSpy completedSpy(&extractor, &Extractor::completed);
+    QSignalSpy errorSpy(&extractor, &Extractor::error);
+
+    extractor.extract(archivePath, dir.path(), QStringLiteral("Test.docset"));
+
+    QCOMPARE(errorSpy.count(), 0);
+    QCOMPARE(completedSpy.count(), 1);
+    QVERIFY(QFile::exists(dir.filePath(QStringLiteral("Test.docset/Contents/Info.plist"))));
+}
+
+void ExtractorTest::testRejectsPathTraversal()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    const QString archivePath = dir.filePath(QStringLiteral("docset.tgz"));
+    QVERIFY(writeArchive(archivePath, {{"Test.docset/../pwned.txt", "owned"}}));
+
+    Extractor extractor;
+    QSignalSpy completedSpy(&extractor, &Extractor::completed);
+    QSignalSpy errorSpy(&extractor, &Extractor::error);
+
+    extractor.extract(archivePath, dir.path(), QStringLiteral("Test.docset"));
+
+    QCOMPARE(completedSpy.count(), 0);
+    QVERIFY(errorSpy.count() > 0);
+    QVERIFY(!QFile::exists(dir.filePath(QStringLiteral("pwned.txt"))));
+}
+
+void ExtractorTest::testRejectsTruncatedArchive()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    // Uncompressed, so the truncation lands on a known tar boundary.
+    const QString archivePath = dir.filePath(QStringLiteral("docset.tar"));
+    QVERIFY(writeArchive(archivePath,
+                         {{"Test.docset/Contents/a.txt", QByteArray(512, 'a')},
+                          {"Test.docset/Contents/b.txt", QByteArray(512, 'b')}},
+                         false));
+
+    // Cut into the middle of the second entry's 512-byte header.
+    QFile file(archivePath);
+    QVERIFY(file.open(QIODevice::ReadWrite));
+    QVERIFY(file.resize(512 + 512 + 256));
+    file.close();
+
+    Extractor extractor;
+    QSignalSpy completedSpy(&extractor, &Extractor::completed);
+    QSignalSpy errorSpy(&extractor, &Extractor::error);
+
+    extractor.extract(archivePath, dir.path(), QStringLiteral("Test.docset"));
+
+    QCOMPARE(completedSpy.count(), 0);
+    QVERIFY(errorSpy.count() > 0);
+    // The first entry was written before the failure; the install is not reported complete.
+    QVERIFY(QFile::exists(dir.filePath(QStringLiteral("Test.docset/Contents/a.txt"))));
+}
+
+QTEST_GUILESS_MAIN(ExtractorTest)
+#include "extractor_test.moc"

--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -260,6 +260,31 @@ void DocsetsDialog::downloadSelectedDocsets()
     }
 }
 
+QTemporaryFile *DocsetsDialog::docsetTemporaryFile(const QString &docsetName)
+{
+    // A name with path separators could escape the cache and storage directories.
+    if (docsetName.contains(QLatin1Char('/')) || docsetName.contains(QLatin1Char('\\'))) {
+        qCWarning(log, "Refusing docset with an unsafe name '%s'.", qPrintable(docsetName));
+        return nullptr;
+    }
+
+    QTemporaryFile *tmpFile = m_tmpFiles.value(docsetName);
+    if (tmpFile != nullptr) {
+        return tmpFile;
+    }
+
+    tmpFile = new QTemporaryFile(QStringLiteral("%1/%2.XXXXXX.tmp").arg(Core::Application::cacheLocation(), docsetName),
+                                 this);
+    if (!tmpFile->open()) {
+        qCWarning(log, "Cannot create a temporary file for '%s'.", qPrintable(docsetName));
+        delete tmpFile;
+        return nullptr;
+    }
+
+    m_tmpFiles.insert(docsetName, tmpFile);
+    return tmpFile;
+}
+
 /*!
   \internal
   Should be connected to all \l QNetworkReply::finished signals in order to process possible
@@ -358,15 +383,16 @@ void DocsetsDialog::downloadCompleted()
             removeDocset(docsetName);
         }
 
-        QTemporaryFile *tmpFile = m_tmpFiles[docsetName];
+        QTemporaryFile *tmpFile = docsetTemporaryFile(docsetName);
         if (tmpFile == nullptr) {
-            tmpFile = new QTemporaryFile(QStringLiteral("%1/%2.XXXXXX.tmp")
-                                             .arg(Core::Application::cacheLocation(), docsetName),
-                                         this);
-            if (!tmpFile->open()) {
-                return;
+            QListWidgetItem *listItem = findDocsetListItem(docsetName);
+            if (listItem != nullptr) {
+                listItem->setData(DocsetListItemDelegate::ShowProgressRole, false);
             }
-            m_tmpFiles.insert(docsetName, tmpFile);
+            QMessageBox::warning(this,
+                                 QStringLiteral("Zeal"),
+                                 tr("Cannot create a temporary file to install <b>%1</b>.").arg(docsetName));
+            break;
         }
 
         while (reply->bytesAvailable() > 0) {
@@ -455,15 +481,9 @@ void DocsetsDialog::downloadProgress(qint64 received, qint64 total)
     if (downloadType(reply) == DownloadType::Docset) {
         const QString docsetName = reply->property(DocsetNameProperty).toString();
 
-        QTemporaryFile *tmpFile = m_tmpFiles[docsetName];
+        QTemporaryFile *tmpFile = docsetTemporaryFile(docsetName);
         if (tmpFile == nullptr) {
-            tmpFile = new QTemporaryFile(QStringLiteral("%1/%2.XXXXXX.tmp")
-                                             .arg(Core::Application::cacheLocation(), docsetName),
-                                         this);
-            if (!tmpFile->open()) {
-                return;
-            }
-            m_tmpFiles.insert(docsetName, tmpFile);
+            return;
         }
 
         tmpFile->write(reply->read(received));

--- a/src/libs/ui/docsetsdialog.h
+++ b/src/libs/ui/docsetsdialog.h
@@ -107,6 +107,10 @@ private:
 
     void updateStatus();
 
+    // Returns the download buffer for a docset, creating it on first use.
+    // Returns nullptr if the temporary file cannot be opened.
+    QTemporaryFile *docsetTemporaryFile(const QString &docsetName);
+
     // FIXME: Come up with a better approach
     QString docsetNameForTmpFilePath(const QString &filePath) const;
 


### PR DESCRIPTION
- Reject archive entries that resolve outside the destination (path traversal).
- Treat non-EOF header-read termination as an extraction failure rather than reporting success on a corrupt or truncated archive.
- Surface an error and reset UI state when a download temporary file cannot be opened, instead of leaving the install silently stuck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction security by rejecting entries that would escape the destination and by verifying proper archive termination to prevent unsafe or truncated extractions.
  * More robust docset installation flow with reusable temporary-file handling and clearer user feedback when temp-file creation fails.

* **Tests**
  * Added unit tests covering successful extraction, directory-traversal rejection, and handling of truncated/malformed archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->