### PR TITLE
feat(core): add --port command-line option

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -4,6 +4,7 @@
 
 #include <core/application.h>
 #include <core/applicationsingleton.h>
+#include <core/httpserver.h>
 #include <registry/searchquery.h>
 #include <ui/widgets/proxystyle.h>
 #include <ui/windowmanager.h>
@@ -30,9 +31,20 @@
 #include <utility> // for std::ignore
 #endif
 
+#include <algorithm>
+#include <array>
 #include <cstdlib>
+#include <limits>
 
 namespace {
+
+// Qt WebEngine is Chromium, which refuses to connect to a fixed set of ports;
+// a server bound to one would be unreachable from the embedded browser. Ports
+// below 1024 are excluded by the unprivileged-range check, so only the
+// restricted ports at or above 1024 need listing here.
+// See net/base/port_util.cc (kRestrictedPorts) in Chromium.
+constexpr std::array<quint16, 17> BrowserRestrictedPorts =
+    {1719, 1720, 1723, 2049, 3659, 4045, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669, 6697, 10080};
 
 #if defined(Q_OS_WINDOWS) && QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 // Windows fills new window client areas with COLOR_WINDOW (always white, even in dark mode)
@@ -74,6 +86,8 @@ struct CommandLineParameters
     bool forceMinimized = false;
     bool preventActivation = false;
 
+    quint16 httpServerPort = 0;
+
 #ifdef Q_OS_WINDOWS
     bool registerProtocolHandlers = false;
     bool unregisterProtocolHandlers = false;
@@ -97,6 +111,14 @@ QString stripParameterUrl(const QString &url, const QString &scheme)
     return str;
 }
 
+// Reports a fatal startup error both on the console and in a dialog, so it is
+// visible whether Zeal was launched from a terminal or a desktop shortcut.
+void showStartupError(const QString &message)
+{
+    QTextStream(stderr) << message << '\n';
+    QMessageBox::critical(nullptr, QObject::tr("Zeal"), message);
+}
+
 CommandLineParameters parseCommandLine(const QStringList &arguments)
 {
     QCommandLineParser parser;
@@ -104,7 +126,10 @@ CommandLineParameters parseCommandLine(const QStringList &arguments)
     parser.addHelpOption();
     parser.addVersionOption();
 
-    parser.addOptions({{QStringLiteral("minimized"), QObject::tr("Start minimized regardless of settings.")}});
+    parser.addOptions({{QStringLiteral("minimized"), QObject::tr("Start minimized regardless of settings.")},
+                       {QStringLiteral("port"),
+                        QObject::tr("Bind the local documentation server to a fixed port."),
+                        QObject::tr("port")}});
 
 #ifdef Q_OS_WINDOWS
     // --attach-console is acted on at the top of main() (before any parsing) so that
@@ -121,6 +146,20 @@ CommandLineParameters parseCommandLine(const QStringList &arguments)
     CommandLineParameters clParams;
     clParams.forceMinimized = parser.isSet(QStringLiteral("minimized"));
     clParams.preventActivation = false;
+
+    if (parser.isSet(QStringLiteral("port"))) {
+        const QString value = parser.value(QStringLiteral("port"));
+        bool ok = false;
+        const uint port = value.toUInt(&ok);
+        const bool restricted = std::ranges::find(BrowserRestrictedPorts, port) != BrowserRestrictedPorts.cend();
+        if (!ok || port < 1024 || port > std::numeric_limits<quint16>::max() || restricted) {
+            showStartupError(QObject::tr("Invalid port: %1. Specify an unprivileged port (1024-65535) that the "
+                                         "browser permits.")
+                                 .arg(value));
+            ::exit(EXIT_FAILURE);
+        }
+        clParams.httpServerPort = static_cast<quint16>(port);
+    }
 
 #ifdef Q_OS_WINDOWS
     clParams.registerProtocolHandlers = parser.isSet(QStringLiteral("register"));
@@ -324,7 +363,15 @@ int main(int argc, char *argv[])
     QDir::setSearchPaths(QStringLiteral("typeIcon"), {QStringLiteral(":/icons/type")});
 
     using Zeal::Core::Application;
-    Application app;
+    Application app(clParams.httpServerPort);
+
+    if (!app.httpServer()->isListening()) {
+        showStartupError(
+            clParams.httpServerPort != 0
+                ? QObject::tr("Failed to bind the documentation server to port %1.").arg(clParams.httpServerPort)
+                : QObject::tr("Failed to start the documentation server."));
+        return EXIT_FAILURE;
+    }
 
     using Zeal::WidgetUi::WindowManager;
     WindowManager wm(&app);

--- a/src/libs/core/application.cpp
+++ b/src/libs/core/application.cpp
@@ -34,7 +34,7 @@ constexpr auto ReleasesApiUrl = "https://api.zealdocs.org/v1/releases"_L1;
 
 Application *Application::m_instance = nullptr;
 
-Application::Application(QObject *parent)
+Application::Application(quint16 httpServerPort, QObject *parent)
     : QObject(parent)
 {
     // Ensure only one instance of Application
@@ -48,7 +48,7 @@ Application::Application(QObject *parent)
     m_networkManager = new NetworkAccessManager(this);
 
     m_fileManager = new FileManager(this);
-    m_httpServer = new HttpServer(this);
+    m_httpServer = new HttpServer(httpServerPort, this);
 
     connect(m_networkManager,
             &QNetworkAccessManager::sslErrors,

--- a/src/libs/core/application.h
+++ b/src/libs/core/application.h
@@ -30,7 +30,7 @@ class Application final : public QObject
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(Application)
 public:
-    explicit Application(QObject *parent = nullptr);
+    explicit Application(quint16 httpServerPort = 0, QObject *parent = nullptr);
     ~Application() override;
 
     static Application *instance();

--- a/src/libs/core/httpserver.cpp
+++ b/src/libs/core/httpserver.cpp
@@ -22,16 +22,26 @@ Q_LOGGING_CATEGORY(log, "zeal.core.httpserver")
 constexpr const char *LocalHttpServerHost = "127.0.0.1"; // macOS only routes 127.0.0.1 by default.
 } // namespace
 
-HttpServer::HttpServer(QObject *parent)
+HttpServer::HttpServer(quint16 port, QObject *parent)
     : QObject(parent)
 {
     m_server = std::make_unique<httplib::Server>();
 
-    const int port = m_server->bind_to_any_port(LocalHttpServerHost);
+    int boundPort = -1;
+    if (port != 0) {
+        boundPort = m_server->bind_to_port(LocalHttpServerHost, port) ? port : -1;
+    } else {
+        boundPort = m_server->bind_to_any_port(LocalHttpServerHost);
+    }
+
+    if (boundPort <= 0) {
+        qCWarning(log, "Failed to bind to %s:%u.", LocalHttpServerHost, port);
+        return;
+    }
 
     m_baseUrl.setScheme(QStringLiteral("http"));
     m_baseUrl.setHost(QString::fromLatin1(LocalHttpServerHost));
-    m_baseUrl.setPort(port);
+    m_baseUrl.setPort(boundPort);
 
     // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape): false positive — cpp-httplib stores the handler by value.
     m_server->set_error_handler([this](const auto &req, auto &res) {
@@ -119,6 +129,11 @@ HttpServer::~HttpServer()
     } catch (const std::future_error &e) {
         qCDebug(log, "Future has no associated state; nothing to wait for: %s.", e.what());
     }
+}
+
+bool HttpServer::isListening() const
+{
+    return !m_baseUrl.isEmpty();
 }
 
 QUrl HttpServer::baseUrl() const

--- a/src/libs/core/httpserver.h
+++ b/src/libs/core/httpserver.h
@@ -29,9 +29,12 @@ public:
     // Returns the file content for a mount-relative path, or nothing if absent.
     using ContentProvider = std::function<std::optional<QByteArray>(const QString &path)>;
 
-    explicit HttpServer(QObject *parent = nullptr);
+    // A non-zero port binds to that specific port; zero binds to a random one.
+    // Binding failure leaves the server not listening; check isListening().
+    explicit HttpServer(quint16 port = 0, QObject *parent = nullptr);
     ~HttpServer() override;
 
+    bool isListening() const;
     QUrl baseUrl() const;
 
     QUrl mount(const QString &prefix, const QString &path);


### PR DESCRIPTION
Fixes #1774.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a command-line option to bind the embedded documentation server to a specific port (including explicit localhost binding and option for automatic port selection).
  * Validate port values to ensure they’re unprivileged and not in restricted-port lists.

* **Bug Fixes**
  * Show clear fatal startup errors (stderr and a critical dialog) and exit if the requested port is invalid or the server fails to start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->