### PR TITLE
feat(registry,ui): show download size in tooltips

### DIFF
--- a/src/libs/registry/docset.cpp
+++ b/src/libs/registry/docset.cpp
@@ -285,6 +285,21 @@ QString Docset::feedUrl() const
     return m_feedUrl;
 }
 
+bool Docset::hasUpdate() const
+{
+    return m_update.has_value();
+}
+
+const std::optional<Docset::UpdateInfo> &Docset::update() const
+{
+    return m_update;
+}
+
+void Docset::setUpdate(std::optional<UpdateInfo> update)
+{
+    m_update = std::move(update);
+}
+
 QString Docset::path() const
 {
     return m_path;

--- a/src/libs/registry/docset.h
+++ b/src/libs/registry/docset.h
@@ -63,8 +63,17 @@ public:
     QList<SearchResult> search(const QString &query, const std::atomic_bool &canceled) const;
     QList<SearchResult> relatedLinks(const QUrl &url) const;
 
-    // FIXME: This is an ugly workaround before we have a proper docset sources implementation
-    bool hasUpdate = false;
+    // Update availability lives here until a proper docset catalog implementation exists.
+    struct UpdateInfo
+    {
+        QString version;
+        int revision = 0;
+        qint64 size = 0; // Compressed archive size in bytes; 0 when unknown (e.g. user dash feeds).
+    };
+
+    bool hasUpdate() const;
+    const std::optional<UpdateInfo> &update() const;
+    void setUpdate(std::optional<UpdateInfo> update);
 
     QUrl baseUrl() const;
     void setBaseUrl(const QUrl &baseUrl);
@@ -114,6 +123,8 @@ private:
     bool m_isJavaScriptEnabled = false;
 
     QUrl m_baseUrl;
+
+    std::optional<UpdateInfo> m_update;
 };
 
 } // namespace Registry

--- a/src/libs/registry/docsetmetadata.cpp
+++ b/src/libs/registry/docsetmetadata.cpp
@@ -43,6 +43,8 @@ DocsetMetadata::DocsetMetadata(const QJsonObject &jsonObject)
     // for comparison to work properly.
     m_revision = jsonObject[QStringLiteral("revision")].toString().toInt();
 
+    m_size = jsonObject[QStringLiteral("size")].toInteger();
+
     m_hasTarix = jsonObject[QStringLiteral("tarix")].toBool();
 
     m_feedUrl = QUrl(jsonObject[QStringLiteral("feed_url")].toString());
@@ -152,6 +154,11 @@ QString DocsetMetadata::latestVersion() const
 int DocsetMetadata::revision() const
 {
     return m_revision;
+}
+
+qint64 DocsetMetadata::size() const
+{
+    return m_size;
 }
 
 bool DocsetMetadata::hasTarix() const

--- a/src/libs/registry/docsetmetadata.h
+++ b/src/libs/registry/docsetmetadata.h
@@ -26,6 +26,7 @@ public:
     QStringList versions() const;
     QString latestVersion() const;
     int revision() const;
+    qint64 size() const;
     QIcon icon() const;
     bool hasTarix() const;
 
@@ -41,6 +42,7 @@ private:
     QStringList m_aliases;
     QStringList m_versions;
     int m_revision = 0;
+    qint64 m_size = 0;
     bool m_hasTarix = false;
 
     QByteArray m_rawIcon;

--- a/src/libs/registry/listmodel.cpp
+++ b/src/libs/registry/listmodel.cpp
@@ -8,6 +8,8 @@
 #include "docsetregistry.h"
 #include "itemdatarole.h"
 
+#include <QLocale>
+
 #include <iterator>
 
 namespace Zeal::Registry {
@@ -99,8 +101,23 @@ QVariant ListModel::data(const QModelIndex &index, int role) const
         if (index.column() != SectionIndex::Name || indexLevel(index) != IndexLevel::Docset) {
             return {};
         }
+
         auto *const docset = itemInRow(index.row())->docset;
-        return tr("Version: %1r%2").arg(docset->version()).arg(docset->revision());
+        QString tooltip = tr("Version: %1r%2").arg(docset->version()).arg(docset->revision());
+        if (docset->hasUpdate()) {
+            const Docset::UpdateInfo &update = docset->update().value();
+            if (update.size > 0) {
+                tooltip += QLatin1Char('\n')
+                         + tr("Update available: %1r%2 (%3)")
+                               .arg(update.version)
+                               .arg(update.revision)
+                               .arg(QLocale::system().formattedDataSize(update.size));
+            } else {
+                tooltip += QLatin1Char('\n') + tr("Update available: %1r%2").arg(update.version).arg(update.revision);
+            }
+        }
+
+        return tooltip;
     }
     case ItemDataRole::UrlRole:
         switch (indexLevel(index)) {
@@ -122,7 +139,8 @@ QVariant ListModel::data(const QModelIndex &index, int role) const
         if (index.parent().isValid()) {
             return {};
         }
-        return itemInRow(index.row())->docset->hasUpdate;
+
+        return itemInRow(index.row())->docset->hasUpdate();
     default:
         return {};
     }

--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -362,7 +362,9 @@ void DocsetsDialog::downloadCompleted()
         } else {
             // Check for feed update
             if (metadata.latestVersion() != docset->version() || metadata.revision() > docset->revision()) {
-                docset->hasUpdate = true;
+                docset->setUpdate(Registry::Docset::UpdateInfo{.version = metadata.latestVersion(),
+                                                               .revision = metadata.revision(),
+                                                               .size = metadata.size()});
 
                 if (!m_isStorageReadOnly) {
                     ui->updateAllDocsetsButton->setEnabled(true);
@@ -812,7 +814,7 @@ QListWidgetItem *DocsetsDialog::findDocsetListItem(const QString &name) const
 bool DocsetsDialog::updatesAvailable() const
 {
     return std::ranges::any_of(m_docsetRegistry->docsets(), [](const Registry::Docset *docset) {
-        return docset->hasUpdate;
+        return docset->hasUpdate();
     });
 }
 
@@ -919,6 +921,19 @@ void DocsetsDialog::processDocsetList(const QJsonArray &list)
         auto *listItem = new QListWidgetItem(metadata.icon(), metadata.title(), ui->availableDocsetList);
         listItem->setData(Registry::ItemDataRole::DocsetNameRole, metadata.name());
 
+        QStringList tooltipLines;
+        if (!metadata.latestVersion().isEmpty()) {
+            tooltipLines << tr("Version: %1r%2").arg(metadata.latestVersion()).arg(metadata.revision());
+        }
+
+        if (metadata.size() > 0) {
+            tooltipLines << tr("Download size: %1").arg(QLocale::system().formattedDataSize(metadata.size()));
+        }
+
+        if (!tooltipLines.isEmpty()) {
+            listItem->setToolTip(tooltipLines.join(QLatin1Char('\n')));
+        }
+
         if (!m_docsetRegistry->contains(metadata.name())) {
             continue;
         }
@@ -928,7 +943,9 @@ void DocsetsDialog::processDocsetList(const QJsonArray &list)
         Registry::Docset *docset = m_docsetRegistry->docset(metadata.name());
 
         if (metadata.latestVersion() != docset->version() || metadata.revision() > docset->revision()) {
-            docset->hasUpdate = true;
+            docset->setUpdate(Registry::Docset::UpdateInfo{.version = metadata.latestVersion(),
+                                                           .revision = metadata.revision(),
+                                                           .size = metadata.size()});
 
             if (!m_isStorageReadOnly) {
                 ui->updateAllDocsetsButton->setEnabled(true);


### PR DESCRIPTION
Fixes #353.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docset updates now include detailed metadata: version, revision and download size.
  * UI tooltips show "Version" and "Download size" lines and formatted download sizes when available.
  * Update state is exposed and persisted per docset so availability is tracked reliably.

* **Bug Fixes**
  * Update availability indicators now evaluate correctly and display consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->