### PR TITLE
feat(ui): add a default zoom level setting

### DIFF
--- a/src/libs/browser/webview.cpp
+++ b/src/libs/browser/webview.cpp
@@ -7,6 +7,8 @@
 #include "webcontrol.h"
 #include "webpage.h"
 
+#include <core/application.h>
+#include <core/settings.h>
 #include <ui/browsertab.h>
 #include <ui/mainwindow.h>
 #include <ui/widgets/iconhelper.h>
@@ -23,13 +25,16 @@
 #include <QWebEngineSettings>
 #include <QWheelEvent>
 
+#include <limits>
+
 namespace Zeal::Browser {
 
 WebView::WebView(QWidget *parent)
     : QWebEngineView(parent)
 {
     setPage(new WebPage(this));
-    setZoomLevel(defaultZoomLevel());
+
+    applyDefaultZoom();
 
     // Enable plugins for PDF support.
     settings()->setAttribute(QWebEngineSettings::PluginsEnabled, true);
@@ -42,6 +47,31 @@ WebView::WebView(QWidget *parent)
 int WebView::zoomLevel() const
 {
     return m_zoomLevel;
+}
+
+void WebView::applyDefaultZoom()
+{
+    setZoomLevel(nearestZoomLevel(Core::Application::instance()->settings()->defaultZoomPercentage));
+}
+
+int WebView::nearestZoomLevel(int percentage)
+{
+    const QList<int> &levels = availableZoomLevels();
+    if (percentage < levels.first() || percentage > levels.last()) {
+        return defaultZoomLevel();
+    }
+
+    int nearest = defaultZoomLevel();
+    int minDelta = std::numeric_limits<int>::max();
+    for (qsizetype i = 0; i < levels.size(); ++i) {
+        const int delta = qAbs(levels.at(i) - percentage);
+        if (delta < minDelta) {
+            minDelta = delta;
+            nearest = static_cast<int>(i);
+        }
+    }
+
+    return nearest;
 }
 
 void WebView::setZoomLevel(int level)
@@ -87,7 +117,7 @@ void WebView::zoomOut()
 
 void WebView::resetZoom()
 {
-    setZoomLevel(defaultZoomLevel());
+    applyDefaultZoom();
 }
 
 QWebEngineView *WebView::createWindow(QWebEnginePage::WebWindowType type)

--- a/src/libs/browser/webview.h
+++ b/src/libs/browser/webview.h
@@ -25,6 +25,7 @@ public:
 
     static const QList<int> &availableZoomLevels();
     static int defaultZoomLevel();
+    static int nearestZoomLevel(int percentage);
 
     void zoomIn();
     void zoomOut();
@@ -38,12 +39,14 @@ protected:
     void contextMenuEvent(QContextMenuEvent *event) override;
 
 private:
+    void applyDefaultZoom();
     bool handleMouseReleaseEvent(QMouseEvent *event);
     bool handleWheelEvent(QWheelEvent *event);
 
     QMenu *m_contextMenu = nullptr;
     QUrl m_clickedLink;
-    int m_zoomLevel = 0;
+    // Invalid index, so the first setZoomLevel() is never skipped.
+    int m_zoomLevel = -1;
 };
 
 } // namespace Zeal::Browser

--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -232,6 +232,8 @@ void Settings::load()
     webSettings->setFontSize(QWebEngineSettings::DefaultFixedFontSize, defaultFixedFontSize);
     webSettings->setFontSize(QWebEngineSettings::MinimumFontSize, minimumFontSize);
 
+    defaultZoomPercentage = settings->value(QStringLiteral("default_zoom_percentage"), 100).toInt();
+
     isHighlightOnNavigateEnabled = settings->value(QStringLiteral("highlight_on_navigate"), true).toBool();
     customCssFile = settings->value(QStringLiteral("custom_css_file")).toString();
     externalLinkPolicy = settings
@@ -321,6 +323,7 @@ void Settings::save()
     settings->setValue(QStringLiteral("default_font_size"), defaultFontSize);
     settings->setValue(QStringLiteral("default_fixed_font_size"), defaultFixedFontSize);
     settings->setValue(QStringLiteral("minimum_font_size"), minimumFontSize);
+    settings->setValue(QStringLiteral("default_zoom_percentage"), defaultZoomPercentage);
 
     settings->setValue(QStringLiteral("appearance"), QVariant::fromValue(contentAppearance));
     settings->setValue(QStringLiteral("highlight_on_navigate"), isHighlightOnNavigateEnabled);

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -56,6 +56,8 @@ public:
     int defaultFixedFontSize;
     int minimumFontSize;
 
+    int defaultZoomPercentage;
+
     enum class ExternalLinkPolicy : unsigned int {
         Ask = 0,
         Open,

--- a/src/libs/ui/mainwindow.cpp
+++ b/src/libs/ui/mainwindow.cpp
@@ -458,10 +458,10 @@ void MainWindow::setupMainMenu()
 
     zoomMenu->addSeparator();
 
-    // -> -> Actual Size Action.
+    // -> -> Reset Zoom Action.
     action = zoomMenu->addAction(IconHelper::fromTheme(QStringLiteral("zoom-original"),
                                                        QStringLiteral(":/icons/tabler/zoom-reset.svg")),
-                                 tr("&Actual Size"));
+                                 tr("&Reset Zoom"));
     addAction(action);
     action->setShortcut(QKeySequence(QStringLiteral("Ctrl+0")));
     connect(action, &QAction::triggered, this, [this]() {

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -6,6 +6,7 @@
 #include "ui_settingsdialog.h"
 
 #include <browser/settings.h>
+#include <browser/webview.h>
 #include <core/application.h>
 #include <core/settings.h>
 #include <qxtglobalshortcut/qxtglobalshortcut.h>
@@ -53,6 +54,10 @@ SettingsDialog::SettingsDialog(QWidget *parent)
         ui->fontSizeComboBox->addItem(QString::number(fontSize), fontSize);
         ui->fixedFontSizeComboBox->addItem(QString::number(fontSize), fontSize);
         ui->minFontSizeComboBox->addItem(QString::number(fontSize), fontSize);
+    }
+
+    for (const int percentage : Browser::WebView::availableZoomLevels()) {
+        ui->defaultZoomComboBox->addItem(QStringLiteral("%1%").arg(percentage), percentage);
     }
 
     // Fix tab order.
@@ -189,6 +194,8 @@ void SettingsDialog::loadSettings()
     ui->fontSizeComboBox->setCurrentText(QString::number(settings->defaultFontSize));
     ui->fixedFontSizeComboBox->setCurrentText(QString::number(settings->defaultFixedFontSize));
     ui->minFontSizeComboBox->setCurrentText(QString::number(settings->minimumFontSize));
+    // Combo box indices mirror WebView::availableZoomLevels().
+    ui->defaultZoomComboBox->setCurrentIndex(Browser::WebView::nearestZoomLevel(settings->defaultZoomPercentage));
 
     switch (settings->contentAppearance) {
     case Core::Settings::ContentAppearance::Automatic:
@@ -283,6 +290,7 @@ void SettingsDialog::saveSettings()
     settings->defaultFontSize = ui->fontSizeComboBox->currentData().toInt();
     settings->defaultFixedFontSize = ui->fixedFontSizeComboBox->currentData().toInt();
     settings->minimumFontSize = ui->minFontSizeComboBox->currentData().toInt();
+    settings->defaultZoomPercentage = ui->defaultZoomComboBox->currentData().toInt();
 
     if (ui->appearanceAutoRadioButton->isChecked()) {
         settings->contentAppearance = Core::Settings::ContentAppearance::Automatic;

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -345,6 +345,36 @@
             </property>
            </widget>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_15">
+            <item>
+             <widget class="QLabel" name="defaultZoomLabel">
+              <property name="text">
+               <string>Default zoom le&amp;vel:</string>
+              </property>
+              <property name="buddy">
+               <cstring>defaultZoomComboBox</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="defaultZoomComboBox"/>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/libs/ui/widgets/browserzoomwidget.cpp
+++ b/src/libs/ui/widgets/browserzoomwidget.cpp
@@ -53,7 +53,7 @@ BrowserZoomWidget::BrowserZoomWidget(QWidget *parent)
     resetButton->setIcon(
         IconHelper::fromTheme(QStringLiteral("zoom-original"), QStringLiteral(":/icons/tabler/rotate-clockwise.svg")));
     resetButton->setText(QStringLiteral("↻"));
-    resetButton->setToolTip(tr("Actual size"));
+    resetButton->setToolTip(tr("Reset zoom"));
     connect(resetButton, &QToolButton::clicked, this, &BrowserZoomWidget::resetZoomRequested);
 
     auto *layout = new QHBoxLayout(this);


### PR DESCRIPTION
The document browser always started at 100%, so a preferred zoom had to be set again after every launch.

This adds a default zoom level to the Style group in Settings > Content. The value applies to newly created web views and is stored as a percentage, so it stays readable in the configuration file and survives changes to WebView::availableZoomLevels(). Zooming within a tab stays temporary, as before.

The zoom reset action and tooltip are renamed from "Actual Size" to "Reset Zoom", which is accurate now that the neutral level is configurable.

Refs #1335.