### PR TITLE
refactor(browser): make short URL keys constexpr

### DIFF
--- a/src/libs/browser/webbridge.cpp
+++ b/src/libs/browser/webbridge.cpp
@@ -6,18 +6,19 @@
 #include <core/application.h>
 
 #include <QDesktopServices>
-#include <QSet>
+#include <QLatin1StringView>
 #include <QUrl>
+
+#include <algorithm>
+#include <array>
 
 namespace Zeal::Browser {
 
 namespace {
-const QSet<QString> AllowedShortUrlKeys = {QStringLiteral("discord"),
-                                           QStringLiteral("github"),
-                                           QStringLiteral("report-bug"),
-                                           QStringLiteral("telegram"),
-                                           QStringLiteral("website"),
-                                           QStringLiteral("x")};
+using Qt::Literals::StringLiterals::operator""_L1;
+
+constexpr std::array AllowedShortUrlKeys =
+    {"discord"_L1, "github"_L1, "report-bug"_L1, "telegram"_L1, "website"_L1, "x"_L1};
 } // namespace
 
 WebBridge::WebBridge(QObject *parent)
@@ -27,7 +28,11 @@ WebBridge::WebBridge(QObject *parent)
 
 void WebBridge::openShortUrl(const QString &key)
 {
-    if (!AllowedShortUrlKeys.contains(key)) {
+    const auto matchesKey = [&key](QLatin1StringView allowed) {
+        return allowed == key;
+    };
+
+    if (std::ranges::none_of(AllowedShortUrlKeys, matchesKey)) {
         return;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when opening short URLs to ensure only supported URL keys are accepted.
  * Makes key checking more consistent and predictable while preserving existing short-URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->