### PR TITLE
fix(app): require Windows 10 1809 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ without a connection. Originally inspired by [Dash](https://kapeli.com/dash), it
   src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg"/></a>
 
 Binary builds for Windows and other installation options are available on the
-[download page](https://zealdocs.org/download).
+[download page](https://zealdocs.org/download). Windows builds require Windows 10 version 1809 or later.
 
 ## How to use
 

--- a/pkg/wix/template.xml
+++ b/pkg/wix/template.xml
@@ -14,6 +14,10 @@
         <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
 
         <Launch Condition="VersionNT64" Message="This package can only be installed on 64-bit versions of Windows." />
+        <!-- Qt supports Windows 10 version 1809 (build 17763) and later. Repair and removal of an
+             existing installation remain possible on older builds, while an upgrade is refused
+             there, since the newer version would not start. -->
+        <Launch Condition="Installed OR WindowsBuild &gt;= 17763" Message="[ProductName] requires Windows 10 version 1809 or later." />
 
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALL_ROOT" />
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -24,6 +24,7 @@
 
 #ifdef Q_OS_WINDOWS
 #include <QAbstractNativeEventFilter>
+#include <QOperatingSystemVersion>
 #include <QPalette>
 #include <QSettings>
 #include <qt_windows.h>
@@ -244,6 +245,18 @@ void unregisterProtocolHandlers(const QHash<QString, QString> &protocols)
 
 int main(int argc, char *argv[])
 {
+#ifdef Q_OS_WINDOWS
+    // Qt supports Windows 10 version 1809 and later. Older builds fail with nothing the user
+    // can act on: Qt6Core links the system ICU, and where icuuc.dll is merely a forwarder to
+    // icu.dll, the loader fails before this point and Windows names the missing library. This
+    // guard covers the rest, where startup gets here but would end without a window or even a
+    // message (see issue #1920). MessageBoxW is used since the platform plugin may be broken.
+    if (QOperatingSystemVersion::current() < QOperatingSystemVersion::Windows10_1809) {
+        MessageBoxW(nullptr, L"Zeal requires Windows 10 version 1809 or later.", L"Zeal", MB_OK | MB_ICONERROR);
+        return EXIT_FAILURE;
+    }
+#endif
+
     // Do not allow Qt version lower than the app was compiled with.
     QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR)
 


### PR DESCRIPTION
Fixes #1920.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows startup compatibility checks for Windows 10 1809 (build 17763) and later, showing an immediate error on unsupported systems.
  * Updated the installer to enforce Windows 10 1809+ for non-installed installs, while keeping repair/removal and existing installations available.
* **Documentation**
  * Improved Download section formatting by displaying the Windows build requirement on the same line as the download link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->