### PR TITLE
build(cmake): bundle MSVC runtime on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,6 +31,12 @@ build:
 run *args: build
     ./build/{{preset}}/zeal "$@"
 
+# Requires the WiX toolset on Windows for the MSI.
+# Build distributable packages for the current preset.
+[group('dev')]
+package: build
+    cmake --build --preset {{preset}} --target package
+
 # Configure, build, and run the test suite.
 [group('dev')]
 test:

--- a/pkg/wix/cpack_pre_build.cmake
+++ b/pkg/wix/cpack_pre_build.cmake
@@ -3,6 +3,17 @@ if(CPACK_SOURCE_INSTALLED_DIRECTORIES)
     return()
 endif()
 
+# A package without the bundled runtime crashes on startup (issue #1658).
+if(NOT CPACK_ZEAL_RUNTIME_LIBS)
+    message(FATAL_ERROR "No MSVC runtime libraries were resolved at configure time.")
+endif()
+
+foreach(_lib ${CPACK_ZEAL_RUNTIME_LIBS})
+    if(NOT EXISTS "${CPACK_TEMPORARY_DIRECTORY}/${_lib}")
+        message(FATAL_ERROR "MSVC runtime ${_lib} is missing from the package.")
+    endif()
+endforeach()
+
 # TODO: Automatically generate list.
 set(_file_list
     "zeal.exe"

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -91,6 +91,17 @@ elseif(WIN32)
     # Install the license alongside the binary.
     install(FILES "${CMAKE_SOURCE_DIR}/COPYING" DESTINATION .)
 
+    # Many machines carry no system-wide MSVC runtime, or one older than the toolset. These
+    # are not KnownDLLs, so app-local copies take precedence over System32 (issue #1658).
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION .)
+    include(InstallRequiredSystemLibraries)
+
+    # File names vary by toolset, so let the packaging check assert on what was resolved.
+    foreach(_lib ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS})
+        get_filename_component(_lib_name "${_lib}" NAME)
+        list(APPEND CPACK_ZEAL_RUNTIME_LIBS "${_lib_name}")
+    endforeach()
+
     if(_use_qt_cmake_commands)
         # Install Qt runtime dependencies.
         install(SCRIPT ${_qt_deploy_script})


### PR DESCRIPTION
Fixes #1658.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development packaging command to build distributable packages for the selected configuration.
  * Windows packaging now includes required Microsoft runtime libraries.

* **Bug Fixes**
  * Added validation to ensure required runtime libraries are present before code signing.
  * Packaging now fails early with a clear error when required files are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->