### PR TITLE
fix(ui): remove partial docset on extract error

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -588,6 +588,13 @@ void DocsetsDialog::extractionError(const QString &filePath, const QString &erro
     delete m_tmpFiles.take(docsetName);
     delete m_tarixIndexFiles.take(docsetName);
 
+    // Remove the partially extracted docset, so it is not loaded on the next start.
+    const QDir dataDir(m_application->settings()->docsetPath);
+    const QString docsetDirectoryName = docsetName + QLatin1String(".docset");
+    if (dataDir.exists(docsetDirectoryName)) {
+        Core::FileManager::removeRecursively(dataDir.filePath(docsetDirectoryName));
+    }
+
     updateStatus();
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaned up partially extracted docset files after extraction errors, preventing incomplete data from remaining in storage.
  * Preserved existing error notifications and progress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->