### PR TITLE
fix(core): remove docsets without blocking the UI

### DIFF
--- a/src/libs/core/filemanager.cpp
+++ b/src/libs/core/filemanager.cpp
@@ -5,14 +5,12 @@
 
 #include "application.h"
 
-#include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
-#include <QFutureWatcher>
 #include <QLoggingCategory>
 
-#include <future>
+#include <thread>
 
 namespace Zeal::Core {
 
@@ -48,17 +46,14 @@ bool FileManager::removeRecursively(const QString &path)
 
     qCDebug(log, "Renamed '%s' to '%s'.", qPrintable(path), qPrintable(deletePath));
 
-    std::future<bool> f = std::async(std::launch::async, [deletePath]() {
-        return QDir(deletePath).removeRecursively();
-    });
+    std::thread([deletePath]() {
+        if (!QDir(deletePath).removeRecursively()) {
+            qCWarning(log, "Failed to remove '%s'.", qPrintable(deletePath));
+            return;
+        }
 
-    f.wait();
-
-    if (!f.get()) {
-        qCWarning(log, "Failed to remove '%s'.", qPrintable(deletePath));
-    } else {
         qCDebug(log, "Removed '%s'.", qPrintable(deletePath));
-    }
+    }).detach();
 
     return true;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory removal responsiveness by allowing the cleanup operation to run in the background.
  * Added success and failure logging for directory removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->