### PR TITLE
fix(core): sweep leftover docset directories

### DIFF
--- a/src/libs/core/application.cpp
+++ b/src/libs/core/application.cpp
@@ -48,6 +48,7 @@ Application::Application(quint16 httpServerPort, QObject *parent)
     m_networkManager = new NetworkAccessManager(this);
 
     m_fileManager = new FileManager(this);
+    FileManager::removePendingDeletions(m_settings->docsetPath);
     m_httpServer = new HttpServer(httpServerPort, this);
 
     connect(m_networkManager,

--- a/src/libs/core/filemanager.cpp
+++ b/src/libs/core/filemanager.cpp
@@ -58,4 +58,41 @@ bool FileManager::removeRecursively(const QString &path)
     return true;
 }
 
+void FileManager::removePendingDeletions(const QString &path)
+{
+    if (path.isEmpty()) {
+        qCWarning(log, "Cannot remove pending deletions without a storage path.");
+        return;
+    }
+
+    std::thread([path]() {
+        const QDir dir(path);
+        QString storagePrefix = dir.canonicalPath();
+        if (storagePrefix.isEmpty()) {
+            qCWarning(log, "Cannot resolve the storage path '%s'.", qPrintable(path));
+            return;
+        }
+
+        if (!storagePrefix.endsWith(QLatin1Char('/'))) {
+            storagePrefix += QLatin1Char('/');
+        }
+
+        const QStringList names = dir.entryList({QStringLiteral("*.deleteme")}, QDir::Dirs | QDir::NoDotAndDotDot);
+        for (const QString &name : names) {
+            const QString deletePath = dir.filePath(name);
+            if (!QFileInfo(deletePath).canonicalFilePath().startsWith(storagePrefix)) {
+                qCWarning(log, "Refusing to remove '%s' outside the storage directory.", qPrintable(deletePath));
+                continue;
+            }
+
+            if (!QDir(deletePath).removeRecursively()) {
+                qCWarning(log, "Failed to remove '%s'.", qPrintable(deletePath));
+                continue;
+            }
+
+            qCDebug(log, "Removed '%s'.", qPrintable(deletePath));
+        }
+    }).detach();
+}
+
 } // namespace Zeal::Core

--- a/src/libs/core/filemanager.h
+++ b/src/libs/core/filemanager.h
@@ -17,6 +17,7 @@ public:
     ~FileManager() override = default;
 
     static bool removeRecursively(const QString &path);
+    static void removePendingDeletions(const QString &path);
 };
 
 } // namespace Zeal::Core


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adds automatic cleanup of pending “delete later” markers (`*.deleteme`) during startup.
  * Cleanup runs in the background to avoid delaying launch.
  * Improves safety by only removing candidates within the configured storage area, refusing anything outside it.
  * Adds clearer log output to indicate when cleanup fails and debug notes when deletions succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->