### PR TITLE
ci(github): revert github/codeql-action to v4

### DIFF
--- a/.github/workflows/analyze-codeql.yaml
+++ b/.github/workflows/analyze-codeql.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.4
+      uses: github/codeql-action/init@v4
       with:
         languages: c-cpp
         build-mode: manual
@@ -61,7 +61,7 @@ jobs:
         buildPreset: release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.4
+      uses: github/codeql-action/analyze@v4
       with:
         upload: failure-only
         output: ${{ runner.temp }}/codeql-sarif
@@ -76,7 +76,7 @@ jobs:
         output: ${{ runner.temp }}/codeql-sarif/cpp.sarif
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v4.37.4
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ runner.temp }}/codeql-sarif/cpp.sarif
         category: .github/workflows/analyze-codeql.yaml:analyze-codeql

--- a/.github/workflows/check-scorecard.yaml
+++ b/.github/workflows/check-scorecard.yaml
@@ -40,6 +40,6 @@ jobs:
         retention-days: 5
 
     - name: Upload to Code Scanning
-      uses: github/codeql-action/upload-sarif@v4.37.4
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: results.sarif


### PR DESCRIPTION
Reverts zealdocs/zeal#1947.

Silly Dependabot 🤦‍♂️ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security analysis workflows to use the latest major version of their scanning and reporting actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->