### PR TITLE
fix(ui): make tray icon readable on dark panels

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -63,6 +63,8 @@ path = [
     "assets/freedesktop/*-apps-zeal.png",
     "assets/freedesktop/sc-apps-zeal.svg",
     "assets/freedesktop/sc-apps-zeal-tray.svg",
+    "assets/freedesktop/sc-apps-zeal-tray-light.svg",
+    "assets/freedesktop/sc-apps-zeal-tray-dark.svg",
     "src/app/resources/zeal.icns",
     "src/app/resources/zeal.ico",
 ]

--- a/assets/freedesktop/CMakeLists.txt
+++ b/assets/freedesktop/CMakeLists.txt
@@ -20,6 +20,8 @@ if(UNIX AND NOT APPLE)
                             "512-apps-zeal.png"
                             "sc-apps-zeal.svg"
                             "sc-apps-zeal-tray.svg"
+                            "sc-apps-zeal-tray-light.svg"
+                            "sc-apps-zeal-tray-dark.svg"
                       DESTINATION ${KDE_INSTALL_ICONDIR}
     )
 

--- a/assets/freedesktop/sc-apps-zeal-tray-dark.svg
+++ b/assets/freedesktop/sc-apps-zeal-tray-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <title>Zeal</title>
+  <desc>Offline documentation browser — dark monochrome Z silhouette for light system tray panels.</desc>
+  <g fill="#000000" transform="translate(8.446 25.000) scale(0.02514 -0.02514)">
+    <path d="M58.667,0L58.667,112.667L376.833,591.167L71,591.167L71,716L534,716L534,603.333L216.333,124.833L541.333,124.833L541.333,0L58.667,0Z"/>
+  </g>
+</svg>

--- a/assets/freedesktop/sc-apps-zeal-tray-light.svg
+++ b/assets/freedesktop/sc-apps-zeal-tray-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <title>Zeal</title>
+  <desc>Offline documentation browser — light monochrome Z silhouette for dark system tray panels.</desc>
+  <g fill="#ffffff" transform="translate(8.446 25.000) scale(0.02514 -0.02514)">
+    <path d="M58.667,0L58.667,112.667L376.833,591.167L71,591.167L71,716L534,716L534,603.333L216.333,124.833L541.333,124.833L541.333,0L58.667,0Z"/>
+  </g>
+</svg>

--- a/assets/freedesktop/sc-apps-zeal-tray.svg
+++ b/assets/freedesktop/sc-apps-zeal-tray.svg
@@ -1,7 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <title>Zeal</title>
   <desc>Offline documentation browser — monochrome Z silhouette for system tray and menu bar icons.</desc>
-  <g transform="translate(8.446 25.000) scale(0.02514 -0.02514)" fill="#000000">
+  <!-- Desktops that recolor tray icons replace this rule with the panel's text
+       color. Those that do not fall back to white, which suits the dark panels
+       such desktops overwhelmingly ship. -->
+  <style id="current-color-scheme" type="text/css">
+    .ColorScheme-Text { color: #ffffff; }
+  </style>
+  <g class="ColorScheme-Text" fill="currentColor" transform="translate(8.446 25.000) scale(0.02514 -0.02514)">
     <path d="M58.667,0L58.667,112.667L376.833,591.167L71,591.167L71,716L534,716L534,603.333L216.333,124.833L541.333,124.833L541.333,0L58.667,0Z"/>
   </g>
 </svg>

--- a/src/app/zeal.qrc
+++ b/src/app/zeal.qrc
@@ -2,6 +2,8 @@
     <qresource prefix="/">
         <file alias="zeal.svg">../../assets/freedesktop/sc-apps-zeal.svg</file>
         <file alias="zeal-tray.svg">../../assets/freedesktop/sc-apps-zeal-tray.svg</file>
+        <file alias="zeal-tray-light.svg">../../assets/freedesktop/sc-apps-zeal-tray-light.svg</file>
+        <file alias="zeal-tray-dark.svg">../../assets/freedesktop/sc-apps-zeal-tray-dark.svg</file>
     </qresource>
     <qresource prefix="/browser">
         <file alias="new-tab.html">resources/browser/new-tab.html</file>

--- a/src/libs/core/settings.cpp
+++ b/src/libs/core/settings.cpp
@@ -47,6 +47,7 @@ Settings::Settings(QObject *parent)
 {
     qRegisterMetaType<ContentAppearance>("ContentAppearance");
     qRegisterMetaType<ExternalLinkPolicy>("ExternalLinkPolicy");
+    qRegisterMetaType<TrayIconStyle>("TrayIconStyle");
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     // When the OS color scheme changes, reapply the color scheme.
@@ -140,6 +141,8 @@ void Settings::load()
     showSystrayIcon = settings->value(QStringLiteral("show_systray_icon"), true).toBool();
     minimizeToSystray = settings->value(QStringLiteral("minimize_to_systray"), false).toBool();
     hideOnClose = settings->value(QStringLiteral("hide_on_close"), false).toBool();
+    trayIconStyle = settings->value(QStringLiteral("systray_icon_style"), QVariant::fromValue(TrayIconStyle::Automatic))
+                        .value<TrayIconStyle>();
 
     settings->beginGroup(GroupUI);
     hideMenuBar = settings->value(QStringLiteral("hide_menu_bar"), false).toBool();
@@ -295,6 +298,7 @@ void Settings::save()
     settings->setValue(QStringLiteral("show_systray_icon"), showSystrayIcon);
     settings->setValue(QStringLiteral("minimize_to_systray"), minimizeToSystray);
     settings->setValue(QStringLiteral("hide_on_close"), hideOnClose);
+    settings->setValue(QStringLiteral("systray_icon_style"), QVariant::fromValue(trayIconStyle));
 
     settings->beginGroup(GroupUI);
     settings->setValue(QStringLiteral("hide_menu_bar"), hideMenuBar);
@@ -448,5 +452,19 @@ QDataStream &operator>>(QDataStream &in, Zeal::Core::Settings::ExternalLinkPolic
     std::underlying_type_t<Zeal::Core::Settings::ExternalLinkPolicy> value = 0;
     in >> value;
     policy = static_cast<Zeal::Core::Settings::ExternalLinkPolicy>(value);
+    return in;
+}
+
+QDataStream &operator<<(QDataStream &out, Zeal::Core::Settings::TrayIconStyle style)
+{
+    out << static_cast<std::underlying_type_t<Zeal::Core::Settings::TrayIconStyle>>(style);
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, Zeal::Core::Settings::TrayIconStyle &style)
+{
+    std::underlying_type_t<Zeal::Core::Settings::TrayIconStyle> value = 0;
+    in >> value;
+    style = static_cast<Zeal::Core::Settings::TrayIconStyle>(value);
     return in;
 }

--- a/src/libs/core/settings.h
+++ b/src/libs/core/settings.h
@@ -35,6 +35,15 @@ public:
     bool minimizeToSystray;
     bool hideOnClose;
 
+    enum class TrayIconStyle : unsigned int {
+        Automatic = 0,
+        Colorful,
+        MonochromeLight,
+        MonochromeDark
+    };
+    Q_ENUM(TrayIconStyle)
+    TrayIconStyle trayIconStyle = TrayIconStyle::Automatic;
+
     // Global Shortcuts
     QKeySequence showShortcut;
     // TODO: QKeySequence searchSelectedTextShortcut;
@@ -148,7 +157,11 @@ QDataStream &operator>>(QDataStream &in, Zeal::Core::Settings::ContentAppearance
 QDataStream &operator<<(QDataStream &out, Zeal::Core::Settings::ExternalLinkPolicy policy);
 QDataStream &operator>>(QDataStream &in, Zeal::Core::Settings::ExternalLinkPolicy &policy);
 
+QDataStream &operator<<(QDataStream &out, Zeal::Core::Settings::TrayIconStyle style);
+QDataStream &operator>>(QDataStream &in, Zeal::Core::Settings::TrayIconStyle &style);
+
 Q_DECLARE_METATYPE(Zeal::Core::Settings::ContentAppearance)
 Q_DECLARE_METATYPE(Zeal::Core::Settings::ExternalLinkPolicy)
+Q_DECLARE_METATYPE(Zeal::Core::Settings::TrayIconStyle)
 
 #endif // ZEAL_CORE_SETTINGS_H

--- a/src/libs/ui/settingsdialog.cpp
+++ b/src/libs/ui/settingsdialog.cpp
@@ -44,6 +44,23 @@ SettingsDialog::SettingsDialog(QWidget *parent)
         }
     });
 
+    // System tray
+    using TrayIconStyle = Core::Settings::TrayIconStyle;
+    ui->trayIconStyleComboBox->addItem(tr("Automatic"), QVariant::fromValue(TrayIconStyle::Automatic));
+    ui->trayIconStyleComboBox->addItem(tr("Colorful"), QVariant::fromValue(TrayIconStyle::Colorful));
+    ui->trayIconStyleComboBox->addItem(tr("Monochrome Light"), QVariant::fromValue(TrayIconStyle::MonochromeLight));
+    ui->trayIconStyleComboBox->addItem(tr("Monochrome Dark"), QVariant::fromValue(TrayIconStyle::MonochromeDark));
+    ui->trayIconStyleComboBox->setToolTip(
+        tr("Automatic lets the desktop tint a monochrome icon to match the panel. Choose a fixed style if the icon is "
+           "hard to see."));
+
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
+    // The platform dictates the icon: a template image on macOS, the full-color
+    // window icon on Windows.
+    ui->trayIconStyleLabel->hide();
+    ui->trayIconStyleComboBox->hide();
+#endif
+
     // Fonts
     ui->defaultFontComboBox->addItem(tr("Serif"), QStringLiteral("serif"));
     ui->defaultFontComboBox->addItem(tr("Sans-serif"), QStringLiteral("sans-serif"));
@@ -166,6 +183,9 @@ void SettingsDialog::loadSettings()
     ui->checkForUpdateCheckBox->setChecked(settings->checkForUpdate);
 
     ui->systrayGroupBox->setChecked(settings->showSystrayIcon);
+    // Fall back to the first entry if the stored style is not a known value.
+    ui->trayIconStyleComboBox->setCurrentIndex(
+        qMax(0, ui->trayIconStyleComboBox->findData(QVariant::fromValue(settings->trayIconStyle))));
     ui->minimizeToSystrayCheckBox->setChecked(settings->minimizeToSystray);
     ui->hideToSystrayCheckBox->setChecked(settings->hideOnClose);
 
@@ -262,6 +282,7 @@ void SettingsDialog::saveSettings()
     settings->checkForUpdate = ui->checkForUpdateCheckBox->isChecked();
 
     settings->showSystrayIcon = ui->systrayGroupBox->isChecked();
+    settings->trayIconStyle = ui->trayIconStyleComboBox->currentData().value<Core::Settings::TrayIconStyle>();
     settings->minimizeToSystray = ui->minimizeToSystrayCheckBox->isChecked();
     settings->hideOnClose = ui->hideToSystrayCheckBox->isChecked();
 

--- a/src/libs/ui/settingsdialog.ui
+++ b/src/libs/ui/settingsdialog.ui
@@ -63,6 +63,23 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
+           <layout class="QFormLayout" name="formLayout_5">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="trayIconStyleLabel">
+              <property name="text">
+               <string>Icon style:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="trayIconStyleComboBox"/>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="QCheckBox" name="minimizeToSystrayCheckBox">
             <property name="text">
              <string>Minimize to system tray instead of taskbar</string>

--- a/src/libs/ui/windowmanager.cpp
+++ b/src/libs/ui/windowmanager.cpp
@@ -20,6 +20,32 @@
 
 namespace Zeal::WidgetUi {
 
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN)
+namespace {
+QIcon themedTrayIcon(Core::Settings::TrayIconStyle style)
+{
+    // Every variant is resolved by theme name so that the tray host receives an
+    // icon name rather than a pixmap. That is what lets desktops recolor the
+    // automatic variant, and lets icon themes override any of them.
+    switch (style) {
+    case Core::Settings::TrayIconStyle::Colorful:
+        return QIcon::fromTheme(QStringLiteral("zeal"), QIcon(QStringLiteral(":/zeal.svg")));
+    case Core::Settings::TrayIconStyle::MonochromeLight:
+        return QIcon::fromTheme(QStringLiteral("zeal-tray-light"), QIcon(QStringLiteral(":/zeal-tray-light.svg")));
+    case Core::Settings::TrayIconStyle::MonochromeDark:
+        return QIcon::fromTheme(QStringLiteral("zeal-tray-dark"), QIcon(QStringLiteral(":/zeal-tray-dark.svg")));
+    case Core::Settings::TrayIconStyle::Automatic:
+        break;
+    }
+
+    // Carries a color scheme stylesheet, so desktops that recolor tray icons tint
+    // it to match the panel. Those that do not fall back to its white default,
+    // hence the explicit choices above (#1950).
+    return QIcon::fromTheme(QStringLiteral("zeal-tray"), QIcon(QStringLiteral(":/zeal-tray.svg")));
+}
+} // namespace
+#endif
+
 WindowManager::WindowManager(Core::Application *application, QObject *parent)
     : QObject(parent)
     , m_application(application)
@@ -117,10 +143,17 @@ MainWindow *WindowManager::activeWindow() const
 
 void WindowManager::applySettings()
 {
-    if (m_settings->isTrayActive()) {
+    if (!m_settings->isTrayActive()) {
+        removeTrayIcon();
+        return;
+    }
+
+    // createTrayIcon() applies the icon itself, so only an already visible icon
+    // needs a refresh, e.g. after the style setting changed.
+    if (m_trayIcon == nullptr) {
         createTrayIcon();
     } else {
-        removeTrayIcon();
+        updateTrayIcon();
     }
 }
 
@@ -131,18 +164,7 @@ void WindowManager::createTrayIcon()
     }
 
     m_trayIcon = new QSystemTrayIcon(this);
-#ifdef Q_OS_MACOS
-    // macOS menu-bar items render as template images: monochrome silhouettes
-    // tinted by the system to match light/dark mode and the active accent.
-    QIcon trayIcon(QStringLiteral(":/zeal-tray.svg"));
-    trayIcon.setIsMask(true);
-#elif defined(Q_OS_WIN)
-    // Windows tray takes the icon as-is — reuse the full-color window icon.
-    const QIcon trayIcon = qApp->windowIcon();
-#else
-    const QIcon trayIcon = QIcon::fromTheme(QStringLiteral("zeal-tray"), QIcon(QStringLiteral(":/zeal-tray.svg")));
-#endif
-    m_trayIcon->setIcon(trayIcon);
+    updateTrayIcon();
     m_trayIcon->setToolTip(QStringLiteral("Zeal"));
 
     connect(m_trayIcon, &QSystemTrayIcon::activated, this, [this](QSystemTrayIcon::ActivationReason reason) {
@@ -181,6 +203,26 @@ void WindowManager::createTrayIcon()
     m_trayIcon->setContextMenu(trayIconMenu);
 
     m_trayIcon->show();
+}
+
+void WindowManager::updateTrayIcon()
+{
+    if (m_trayIcon == nullptr) {
+        return;
+    }
+
+#ifdef Q_OS_MACOS
+    // macOS menu-bar items render as template images: monochrome silhouettes
+    // tinted by the system to match light/dark mode and the active accent.
+    QIcon trayIcon(QStringLiteral(":/zeal-tray.svg"));
+    trayIcon.setIsMask(true);
+#elif defined(Q_OS_WIN)
+    // Windows tray takes the icon as-is — reuse the full-color window icon.
+    const QIcon trayIcon = qApp->windowIcon();
+#else
+    const QIcon trayIcon = themedTrayIcon(m_settings->trayIconStyle);
+#endif
+    m_trayIcon->setIcon(trayIcon);
 }
 
 void WindowManager::removeTrayIcon()

--- a/src/libs/ui/windowmanager.h
+++ b/src/libs/ui/windowmanager.h
@@ -41,6 +41,7 @@ private:
 
     void applySettings();
     void createTrayIcon();
+    void updateTrayIcon();
     void removeTrayIcon();
 
     Core::Application *m_application = nullptr;


### PR DESCRIPTION
Fixes #1950.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable system tray icon styles: Automatic, Colorful, Monochrome Light, and Monochrome Dark.
  * Tray icons now adapt to the selected style and system theme.
  * Icon style preferences are saved and restored between sessions.
  * Added light and dark tray icon assets for supported desktop environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->