### PR TITLE
fix(ui): discard partial archive on failed download

### DIFF
--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -310,6 +310,14 @@ void DocsetsDialog::processDownload(QNetworkReply *reply)
         }
 
         if (reply->error() != QNetworkReply::OperationCanceledError) {
+            const auto type = downloadType(reply);
+            const QString docsetName = reply->property(DocsetNameProperty).toString();
+
+            // Downloads cannot be resumed, so a retry would append to whatever was received.
+            if (type == DownloadType::Docset) {
+                delete m_tmpFiles.take(docsetName);
+            }
+
             const QString msg = tr("Download failed!<br><br><b>Error:</b> %1<br><b>URL:</b> %2")
                                     .arg(reply->errorString().toHtmlEscaped(),
                                          reply->request().url().toString().toHtmlEscaped());
@@ -320,8 +328,8 @@ void DocsetsDialog::processDownload(QNetworkReply *reply)
 
             if (ret == QMessageBox::Retry) {
                 enqueueDownload({.url = reply->request().url(),
-                                 .type = downloadType(reply),
-                                 .docsetName = reply->property(DocsetNameProperty).toString(),
+                                 .type = type,
+                                 .docsetName = docsetName,
                                  .listItemIndex = reply->property(ListItemIndexProperty).toInt()});
                 return;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failed docset downloads leaving partial temporary data behind.
  * Retrying a failed download now starts cleanly instead of appending to incomplete data.
  * Retry behavior now consistently preserves the selected download details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->