### PR TITLE
build(cmake): require toml++ 3.4 and httplib 0.11

### DIFF
--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -24,7 +24,8 @@ find_package(LibArchive REQUIRED)
 target_link_libraries(Core PRIVATE LibArchive::LibArchive)
 
 # Configure toml++ (header-only).
-find_package(tomlplusplus CONFIG)
+# 3.4.0 renamed toml.h to toml.hpp.
+find_package(tomlplusplus 3.4.0 CONFIG)
 if(tomlplusplus_FOUND)
     target_link_libraries(Core PRIVATE tomlplusplus::tomlplusplus)
 else()
@@ -35,7 +36,8 @@ endif()
 # Configure cpp-httplib.
 add_definitions(-DCPPHTTPLIB_USE_POLL)
 
-find_package(httplib CONFIG)
+# 0.11.0 added the set_content(const char *, size_t, ...) overload.
+find_package(httplib 0.11.0 CONFIG)
 if(httplib_FOUND)
     target_link_libraries(Core PRIVATE httplib::httplib)
 else()


### PR DESCRIPTION
Fixes #1958.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated minimum supported versions for bundled build integrations.
  - Existing fallback behavior remains unchanged when compatible bundled copies are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->