### PR TITLE
build(cmake): fix cpp-httplib version floor check

### DIFF
--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -36,8 +36,14 @@ endif()
 # Configure cpp-httplib.
 add_definitions(-DCPPHTTPLIB_USE_POLL)
 
+# SameMinorVersion in httplib's config pins 0.x, so the floor is checked here instead.
 # 0.11.0 added the set_content(const char *, size_t, ...) overload.
-find_package(httplib 0.11.0 CONFIG)
+find_package(httplib CONFIG)
+if(httplib_FOUND AND httplib_VERSION VERSION_LESS 0.11.0)
+    message(STATUS "Ignoring cpp-httplib ${httplib_VERSION}, 0.11.0 or newer required")
+    set(httplib_FOUND FALSE)
+endif()
+
 if(httplib_FOUND)
     target_link_libraries(Core PRIVATE httplib::httplib)
 else()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cpp-httplib version handling by accepting compatible configured versions while falling back to the bundled implementation when the detected version is too old.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->