### PR TITLE
build(cmake): report toml++ and httplib versions

### DIFF
--- a/cmake/ZealHelpers.cmake
+++ b/cmake/ZealHelpers.cmake
@@ -27,3 +27,14 @@ endfunction()
 function(zeal_attach_qt_pch target)
     target_precompile_headers(${target} PRIVATE <QObject> <QString> ${ARGN})
 endfunction()
+
+# Read the version of a bundled dependency out of its header. `regex` must
+# select the single line carrying it, e.g. "^#define CPPHTTPLIB_VERSION ".
+function(zeal_bundled_version out_var header regex)
+    file(STRINGS "${header}" line LIMIT_COUNT 1 REGEX "${regex}")
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" version "${line}")
+    if(NOT version)
+        message(FATAL_ERROR "Could not read a version matching '${regex}' from ${header}")
+    endif()
+    set(${out_var} "${version}" PARENT_SCOPE)
+endfunction()

--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -23,14 +23,24 @@ zeal_attach_qt_pch(Core <QDir>)
 find_package(LibArchive REQUIRED)
 target_link_libraries(Core PRIVATE LibArchive::LibArchive)
 
+include(FindPackageHandleStandardArgs)
+
 # Configure toml++ (header-only).
 # 3.4.0 renamed toml.h to toml.hpp.
-find_package(tomlplusplus 3.4.0 CONFIG)
+# QUIET: falling back to the bundled copy is not a failure.
+find_package(tomlplusplus 3.4.0 CONFIG QUIET)
 if(tomlplusplus_FOUND)
+    find_package_handle_standard_args(tomlplusplus CONFIG_MODE)
     target_link_libraries(Core PRIVATE tomlplusplus::tomlplusplus)
 else()
-    message(STATUS "Using bundled tomlplusplus")
-    target_include_directories(Core PRIVATE "${CMAKE_SOURCE_DIR}/src/contrib/tomlplusplus")
+    set(tomlplusplus_bundled_dir "${CMAKE_SOURCE_DIR}/src/contrib/tomlplusplus")
+    zeal_bundled_version(tomlplusplus_bundled_version
+        "${tomlplusplus_bundled_dir}/toml++/toml.hpp"
+        "^// toml\\+\\+ v")
+    find_package_handle_standard_args(tomlplusplus
+        REQUIRED_VARS tomlplusplus_bundled_dir
+        VERSION_VAR tomlplusplus_bundled_version)
+    target_include_directories(Core PRIVATE "${tomlplusplus_bundled_dir}")
 endif()
 
 # Configure cpp-httplib.
@@ -38,17 +48,24 @@ add_definitions(-DCPPHTTPLIB_USE_POLL)
 
 # SameMinorVersion in httplib's config pins 0.x, so the floor is checked here instead.
 # 0.11.0 added the set_content(const char *, size_t, ...) overload.
-find_package(httplib CONFIG)
+find_package(httplib CONFIG QUIET)
 if(httplib_FOUND AND httplib_VERSION VERSION_LESS 0.11.0)
     message(STATUS "Ignoring cpp-httplib ${httplib_VERSION}, 0.11.0 or newer required")
     set(httplib_FOUND FALSE)
 endif()
 
 if(httplib_FOUND)
+    find_package_handle_standard_args(httplib CONFIG_MODE)
     target_link_libraries(Core PRIVATE httplib::httplib)
 else()
-    message(STATUS "Using bundled cpp-httplib")
-    include_directories("${CMAKE_SOURCE_DIR}/src/contrib/cpp-httplib")
+    set(httplib_bundled_dir "${CMAKE_SOURCE_DIR}/src/contrib/cpp-httplib")
+    zeal_bundled_version(httplib_bundled_version
+        "${httplib_bundled_dir}/httplib.h"
+        "^#define CPPHTTPLIB_VERSION ")
+    find_package_handle_standard_args(httplib
+        REQUIRED_VARS httplib_bundled_dir
+        VERSION_VAR httplib_bundled_version)
+    include_directories("${httplib_bundled_dir}")
 endif()
 
 # Required by cpp-httplib.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Packaging**
  * Improved dependency detection and reporting during configuration.
  * Bundled dependencies now report their detected versions.
  * Missing or incompatible dependencies continue to produce clear configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->