### PR TITLE
build(cmake): mark bundled headers as system

### DIFF
--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
     find_package_handle_standard_args(tomlplusplus
         REQUIRED_VARS tomlplusplus_bundled_dir
         VERSION_VAR tomlplusplus_bundled_version)
-    target_include_directories(Core PRIVATE "${tomlplusplus_bundled_dir}")
+    target_include_directories(Core SYSTEM PRIVATE "${tomlplusplus_bundled_dir}")
 endif()
 
 # Configure cpp-httplib.
@@ -65,7 +65,7 @@ else()
     find_package_handle_standard_args(httplib
         REQUIRED_VARS httplib_bundled_dir
         VERSION_VAR httplib_bundled_version)
-    include_directories("${httplib_bundled_dir}")
+    target_include_directories(Core SYSTEM PRIVATE "${httplib_bundled_dir}")
 endif()
 
 # Required by cpp-httplib.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal library include handling to reduce compiler warning noise without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->