### PR TITLE
ci(github): install Qt TaskTree module

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -17,6 +17,7 @@ env:
   QT_VERSION: "6.11.1"
   QT_MODULES: >-
     qtpositioning
+    qttasktree
     qtwebchannel
     qtwebengine
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ env:
   QT_VERSION: "6.11.1"
   QT_MODULES: >-
     qtpositioning
+    qttasktree
     qtwebchannel
     qtwebengine
 


### PR DESCRIPTION
Silence the build time warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Windows and macOS build checks to include the required Qt Task Tree module.
  - Updated release builds to install the Qt Task Tree module alongside the existing Qt components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->