### PR TITLE
build(cmake): report disabled global shortcuts

### DIFF
--- a/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
+++ b/src/libs/ui/qxtglobalshortcut/CMakeLists.txt
@@ -13,6 +13,7 @@ elseif(UNIX)
             qxtglobalshortcut_x11.cpp
         )
     else()
+        message(STATUS "Global shortcuts disabled: xcb, xcb-keysyms, or xkbcommon not found")
         list(APPEND QxtGlobalShortcut_SOURCES
             qxtglobalshortcut_noop.cpp
         )
@@ -22,6 +23,7 @@ elseif(WIN32)
         qxtglobalshortcut_win.cpp
     )
 else()
+    message(STATUS "Global shortcuts disabled: unsupported platform")
     list(APPEND QxtGlobalShortcut_SOURCES
         qxtglobalshortcut_noop.cpp
     )


### PR DESCRIPTION
Make build-time disablement of global shortcuts more visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added build-time status messages explaining when global shortcuts are unavailable because required platform support is missing.
  - Clarified when shortcuts are disabled on unsupported platforms while the fallback behavior remains in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->