### PR TITLE
fix(ui): show tarix docset install progress

### DIFF
--- a/src/libs/core/extractor.cpp
+++ b/src/libs/core/extractor.cpp
@@ -17,6 +17,11 @@ namespace Zeal::Core {
 
 namespace {
 Q_LOGGING_CATEGORY(log, "zeal.core.extractor")
+
+int percent(qint64 fraction, qint64 total)
+{
+    return static_cast<int>(fraction * 100 / total);
+}
 } // namespace
 
 Extractor::Extractor(QObject *parent)
@@ -122,6 +127,9 @@ bool Extractor::extractEntries(const QString &sourceFile,
     // TODO: Do not strip root directory in archive if it equals to 'root'
     archive_entry *entry = nullptr;
     while ((rc = archive_read_next_header(info.archiveHandle, &entry)) == ARCHIVE_OK) {
+        // Reading the header consumes the previous entry's data, skipped entries included.
+        emitProgress(info);
+
         // See https://github.com/libarchive/libarchive/issues/587 for more on UTF-8.
         QString pathname = QString::fromUtf8(archive_entry_pathname_utf8(entry));
 
@@ -191,8 +199,6 @@ bool Extractor::extractEntries(const QString &sourceFile,
                 return false;
             }
         }
-
-        emitProgress(info);
     }
 
     if (rc != ARCHIVE_EOF) {
@@ -201,6 +207,9 @@ bool Extractor::extractEntries(const QString &sourceFile,
         archive_read_free(info.archiveHandle);
         return false;
     }
+
+    // The read that reported EOF consumed the last entry's data, which no loop iteration saw.
+    emitProgress(info);
 
     archive_read_free(info.archiveHandle);
     return true;
@@ -263,6 +272,12 @@ void Extractor::emitProgress(ExtractInfo &info)
 {
     const qint64 extractedBytes = archive_filter_bytes(info.archiveHandle, -1);
     if (extractedBytes == info.extractedBytes) {
+        return;
+    }
+
+    // progress() is queued to the UI thread and this runs once per archive entry.
+    if (info.totalBytes > 0
+        && percent(extractedBytes, info.totalBytes) == percent(info.extractedBytes, info.totalBytes)) {
         return;
     }
 

--- a/src/libs/ui/docsetsdialog.cpp
+++ b/src/libs/ui/docsetsdialog.cpp
@@ -534,22 +534,25 @@ void DocsetsDialog::downloadProgress(qint64 received, qint64 total)
         return;
     }
 
-    if (downloadType(reply) == DownloadType::Docset) {
-        const QString docsetName = reply->property(DocsetNameProperty).toString();
-
-        QTemporaryFile *tmpFile = docsetTemporaryFile(docsetName);
-        if (tmpFile == nullptr) {
-            return;
-        }
-
-        if (!drainReply(reply, tmpFile)) {
-            reply->setProperty(WriteFailedProperty, true);
-            reply->abort();
-            return;
-        }
+    // The tarix index download reuses the docset's list item.
+    if (downloadType(reply) != DownloadType::Docset) {
+        return;
     }
 
-    // Don't show progress for non-docset pages
+    const QString docsetName = reply->property(DocsetNameProperty).toString();
+
+    QTemporaryFile *tmpFile = docsetTemporaryFile(docsetName);
+    if (tmpFile == nullptr) {
+        return;
+    }
+
+    if (!drainReply(reply, tmpFile)) {
+        reply->setProperty(WriteFailedProperty, true);
+        reply->abort();
+        return;
+    }
+
+    // Wait for a known download size.
     if (total == -1 || received < 10240) {
         return;
     }
@@ -633,6 +636,7 @@ void DocsetsDialog::extractionProgress(const QString &filePath, qint64 extracted
     const QString docsetName = docsetNameForTmpFilePath(filePath);
     QListWidgetItem *listItem = findDocsetListItem(docsetName);
     if (listItem != nullptr) {
+        listItem->setData(DocsetListItemDelegate::FormatRole, tr("Installing: %p%"));
         listItem->setData(DocsetListItemDelegate::ValueRole, percent(extracted, total));
     }
 }
@@ -934,6 +938,10 @@ void DocsetsDialog::startDownload(const DownloadRequest &request)
     connect(reply, &QNetworkReply::downloadProgress, this, &DocsetsDialog::downloadProgress);
     connect(reply, &QNetworkReply::finished, this, &DocsetsDialog::downloadCompleted);
     m_replies.append(reply);
+
+    if (request.type != DownloadType::Docset) {
+        return;
+    }
 
     QListWidgetItem *listItem = ui->availableDocsetList->item(request.listItemIndex);
     if (listItem != nullptr && listItem->data(DocsetListItemDelegate::ShowProgressRole).toBool()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction progress updates for smoother, more accurate completion reporting.
  * Download progress is now shown only for docset downloads, preventing unrelated index downloads from displaying incorrect status.
  * Docset installation now displays a dedicated “Installing” progress status.
  * Improved handling and reporting of download write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->