### PR TITLE
fix(registry): search symbols containing a colon

### DIFF
--- a/src/libs/registry/docsetregistry.cpp
+++ b/src/libs/registry/docsetregistry.cpp
@@ -302,17 +302,22 @@ void DocsetRegistry::runQuery(const QString &query)
     QList<Docset *> enabledDocsets;
 
     const SearchQuery searchQuery = SearchQuery::fromString(query);
+    QString queryString = searchQuery.query();
+
     if (searchQuery.hasKeywords()) {
         for (Docset *docset : std::as_const(m_docsets)) {
             if (searchQuery.hasKeywords(docset->keywords())) {
                 enabledDocsets << docset;
             }
         }
-    } else {
-        enabledDocsets = docsets();
     }
 
-    const QString queryString = searchQuery.query();
+    // A colon is not always a keyword separator, it can be part of a symbol name, e.g. 'xsl:if'.
+    if (enabledDocsets.isEmpty()) {
+        enabledDocsets = docsets();
+        queryString = query.trimmed();
+    }
+
     const QFuture<QList<SearchResult>> queryFuture = QtConcurrent::mappedReduced(enabledDocsets,
                                                                                  [this, &queryString](Docset *docset) {
         return docset->search(queryString, m_cancelSearch);


### PR DESCRIPTION
Fixes #428.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search handling for symbol names containing colons, such as `xsl:if`.
  - Searches now check all available docsets when keyword filtering finds no matches.
  - Queries without recognized keywords now search using the complete entered text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->