### PR TITLE
fix(ui): give macOS its own tray template asset

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -66,6 +66,7 @@ path = [
     "assets/freedesktop/sc-apps-zeal-tray-light.svg",
     "assets/freedesktop/sc-apps-zeal-tray-dark.svg",
     "assets/freedesktop/sc-apps-zeal-tray-symbolic.svg",
+    "src/app/resources/zeal-tray-template.svg",
     "src/app/resources/zeal.icns",
     "src/app/resources/zeal.ico",
 ]

--- a/assets/freedesktop/sc-apps-zeal-tray-symbolic.svg
+++ b/assets/freedesktop/sc-apps-zeal-tray-symbolic.svg
@@ -1,9 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <title>Zeal</title>
   <desc>Offline documentation browser — monochrome Z silhouette for system tray and menu bar icons.</desc>
-  <!-- KDE replaces this rule with the panel's text color. Renderers that ignore
-       CSS fall back to the color attribute below, which the rule outranks in the
-       cascade, so both paths end up with a visible glyph. -->
+  <!-- KDE replaces this rule with the panel's text color; renderers that
+       ignore CSS fall back to the color attribute below, which it outranks. -->
   <style id="current-color-scheme" type="text/css">
     .ColorScheme-Text { color: #ffffff; }
   </style>

--- a/assets/freedesktop/sc-apps-zeal-tray.svg
+++ b/assets/freedesktop/sc-apps-zeal-tray.svg
@@ -1,9 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <title>Zeal</title>
   <desc>Offline documentation browser — monochrome Z silhouette for system tray and menu bar icons.</desc>
-  <!-- KDE replaces this rule with the panel's text color. Renderers that ignore
-       CSS fall back to the color attribute below, which the rule outranks in the
-       cascade, so both paths end up with a visible glyph. -->
+  <!-- KDE replaces this rule with the panel's text color; renderers that
+       ignore CSS fall back to the color attribute below, which it outranks. -->
   <style id="current-color-scheme" type="text/css">
     .ColorScheme-Text { color: #ffffff; }
   </style>

--- a/src/app/resources/zeal-tray-template.svg
+++ b/src/app/resources/zeal-tray-template.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <title>Zeal</title>
+  <desc>Offline documentation browser — monochrome Z silhouette for the macOS menu bar.</desc>
+  <g fill="#000000" transform="translate(6.347 27.500) scale(0.03212 -0.03212)">
+    <path d="M58.667,0L58.667,112.667L376.833,591.167L71,591.167L71,716L534,716L534,603.333L216.333,124.833L541.333,124.833L541.333,0L58.667,0Z"/>
+  </g>
+</svg>

--- a/src/app/zeal.qrc
+++ b/src/app/zeal.qrc
@@ -1,10 +1,10 @@
 <RCC>
     <qresource prefix="/">
         <file alias="zeal.svg">../../assets/freedesktop/sc-apps-zeal.svg</file>
-        <file alias="zeal-tray.svg">../../assets/freedesktop/sc-apps-zeal-tray.svg</file>
         <file alias="zeal-tray-light.svg">../../assets/freedesktop/sc-apps-zeal-tray-light.svg</file>
         <file alias="zeal-tray-dark.svg">../../assets/freedesktop/sc-apps-zeal-tray-dark.svg</file>
         <file alias="zeal-tray-symbolic.svg">../../assets/freedesktop/sc-apps-zeal-tray-symbolic.svg</file>
+        <file alias="zeal-tray-template.svg">resources/zeal-tray-template.svg</file>
     </qresource>
     <qresource prefix="/browser">
         <file alias="new-tab.html">resources/browser/new-tab.html</file>

--- a/src/libs/ui/windowmanager.cpp
+++ b/src/libs/ui/windowmanager.cpp
@@ -38,15 +38,11 @@ QIcon themedTrayIcon(Core::Settings::TrayIconStyle style)
         break;
     }
 
-    // Two recoloring conventions, one file: the "-symbolic" suffix is what GNOME and
-    // Quickshell-based shells key off, while Plasma instead substitutes the SVG's
-    // ColorScheme-Text rule. Hosts doing neither fall back to its white default,
-    // hence the explicit choices above (#1950).
-    //
-    // Only a theme hit carries a name to the host. An icon built from the Qt resource
-    // reports no QIcon::name(), so QDBusTrayIcon sends a bare pixmap and nothing can
-    // tell the glyph is tintable. zeal-tray stays as a named fallback for icon themes
-    // that already override it.
+    // Named "-symbolic" for GNOME and Quickshell-based shells, which tint by name; KDE
+    // instead substitutes the SVG's ColorScheme-Text rule, carried by the same file. Hosts
+    // doing neither fall back to its white default (#1950). The theme lookup has to hit:
+    // an icon built from the Qt resource has no QIcon::name(), so QDBusTrayIcon would send
+    // a bare pixmap and nothing could tell the glyph is tintable.
     return QIcon::fromTheme(QStringLiteral("zeal-tray-symbolic"),
                             QIcon::fromTheme(QStringLiteral("zeal-tray"),
                                              QIcon(QStringLiteral(":/zeal-tray-symbolic.svg"))));
@@ -221,8 +217,10 @@ void WindowManager::updateTrayIcon()
 
 #ifdef Q_OS_MACOS
     // macOS menu-bar items render as template images: monochrome silhouettes
-    // tinted by the system to match light/dark mode and the active accent.
-    QIcon trayIcon(QStringLiteral(":/zeal-tray.svg"));
+    // tinted by the system to match light/dark mode and the active accent. Its own asset
+    // rather than the tray one: extras sit in a fixed 22pt working area that expects less
+    // fill than a freedesktop panel.
+    QIcon trayIcon(QStringLiteral(":/zeal-tray-template.svg"));
     trayIcon.setIsMask(true);
 #elif defined(Q_OS_WIN)
     // Windows tray takes the icon as-is — reuse the full-color window icon.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tray icon handling on macOS by using the appropriate template asset for more consistent display.
  * Clarified fallback behavior for automatically selected tray icons.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->